### PR TITLE
Ahora las respuestas del supervisor se ven correctamente en la vista_detallle

### DIFF
--- a/src/app/vistas/detalle-practica/detalle-practica.component.css
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.css
@@ -1,5 +1,5 @@
 .overflow-auto {
-    max-height: 150px;
+    max-height: 200px;
     font-size: medium;
 }
 

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -357,14 +357,14 @@
                                                     </thead>
                                                     <tbody>
                                                         <tr *ngFor="let resp of respuestas_sup_parsed;">
-                                                            <td>{{resp[1]}}</td>
-                                                            <td *ngIf="resp[0];else textoSolo">
+                                                            <td style="vertical-align: middle;">{{resp[1]}}</td>
+                                                            <td *ngIf="resp[0];else textoSolo" style="vertical-align: middle;">
                                                                 {{resp[2]}}
                                                             </td>
-                                                            <ng-template #textoSolo>
-                                                                <td>
+                                                            <ng-template #textoSolo style="vertical-align: middle;">
+                                                                <td style="vertical-align: middle;">
                                                                     {{resp[2][0]}}
-                                                                    <span class="bg-gradient-success">
+                                                                    <span class="bg-gradient-success" style="vertical-align: middle;">
                                                                         {{resp[2][1]}}
                                                                     </span>
                                                                     {{resp[2][2]}}

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -103,7 +103,22 @@ export class DetallePracticaComponent implements OnInit {
           for(let i=0; i<this.informes.length; i++){
             this.horas_totales += this.informes[i].horas_trabajadas;
           }
-          console.log("HORAS TOTALES", this.horas_totales)
+
+          for(let i=0; i<this.respuestas_supervisor.length; i++){
+            if(this.respuestas_supervisor[i].pregunta_supervisor.tipo_respuesta != "abierta"){
+              let opciones = this.respuestas_supervisor[i].pregunta_supervisor.opciones.split(";;");
+              let respuestas = this.respuestas_supervisor[i].respuesta.split(",");
+              let respuestas_traducidas = "";
+              for(let j=0; j<opciones.length; j++){
+                if(respuestas[j] == "1"){
+                  respuestas_traducidas += opciones[j] + ", ";
+                }          
+              }              
+              respuestas_traducidas = respuestas_traducidas.slice(0, -2);
+              console.log(respuestas_traducidas);
+              this.respuestas_supervisor[i].respuesta = respuestas_traducidas;
+            }
+          }
         }
       }); // fin request para obtener la practica  
     }


### PR DESCRIPTION
Ir a la vista de detalle del encargado
Ver la tabla de reseñas supervisor
Ver que las respuestas ya no aparecen como "1,0,0,1" sino que aparece texto que corresponde a las alternativas de las preguntas

Closes #113 