### PR TITLE
Cambios en vista alumno y detalles para arregar tablas de documentos

### DIFF
--- a/src/app/servicios/alumno/obtener_datos.service.ts
+++ b/src/app/servicios/alumno/obtener_datos.service.ts
@@ -46,4 +46,9 @@ export class ObtenerDatosService {
     const req = new HttpRequest('GET', `${environment.url_back}/informe/todos_practica?id_practica=${id_practica}`);
     return this._http.request(req);
   }
+
+  obtener_solicitudes_documentos_practica(id_config_practica: number, id_practica: number){
+    const req = new HttpRequest('GET', `${environment.url_back}/solicitud_documento/todos_docs_practica?id=${id_config_practica}&id_practica=${id_practica}`);
+    return this._http.request(req);
+  }
 }

--- a/src/app/servicios/encargado/detalle-practica.service.ts
+++ b/src/app/servicios/encargado/detalle-practica.service.ts
@@ -12,7 +12,7 @@ export class DetallePracticaService {
   constructor(private _http: HttpClient) { }
 
   obtener_practica(id_practica: number) {
-    const req = new HttpRequest('GET', `${environment.url_back}/practica/?id=${id_practica}/get_asEncargado`);
+    const req = new HttpRequest('GET', `${environment.url_back}/practica/?id=${id_practica}`);
     return this._http.request(req);
   }
 
@@ -25,4 +25,11 @@ export class DetallePracticaService {
     const req = new HttpRequest('GET', `${environment.url_back}/documento_extra/get?id_practica=${id_practica}`);
     return this._http.request(req);
   }
+
+  obtener_solicitudes_documentos(id_practica: number, id_config_practica: number) {
+    const req = new HttpRequest('GET', `${environment.url_back}/solicitud_documento/todos_docs_practica?id=${id_config_practica}&id_practica=${id_practica}`);
+    return this._http.request(req);
+  }
+
+
 }

--- a/src/app/vistas/alumno/alumno.component.html
+++ b/src/app/vistas/alumno/alumno.component.html
@@ -194,7 +194,7 @@
                                                                                             </tr>
                                                                                         </thead>
                                                                                         <tbody>
-                                                                                            <tr *ngFor="let solicitud of practica[1].modalidad.config_practica.solicitud_documentos;">
+                                                                                            <tr *ngFor="let solicitud of solicitudes_practicas[i];">
                                                                                                 <td>{{solicitud?.nombre_solicitud}}</td>
                                                                                                 <td>{{solicitud?.tipo_archivo}}</td>
                                                                                                 <td>Normal</td>                                                                                                

--- a/src/app/vistas/alumno/alumno.component.ts
+++ b/src/app/vistas/alumno/alumno.component.ts
@@ -19,6 +19,7 @@ export class DetalleAlumnoComponent implements OnInit{
   estudiante: any = {} 
   config_practicas: any = [];
   practicas: any = [];
+  solicitudes_practicas: any = [];
 
   estado_config:string = "";
 
@@ -131,6 +132,17 @@ export class DetalleAlumnoComponent implements OnInit{
                 //element.documento.solicitud_documento.tipo_archivo = element.documento.solicitud_documento.tipo_archivo.split(",");
                 this.practicas_correspondiente_nombre[index].push(element);                    
               }
+              // make a request to get all solicitudes_documentos for the current practica, using /todos_docs_practica
+              this.service_datos.obtener_solicitudes_documentos_practica(element.modalidad.config_practica.id, element.id).subscribe({
+                next: (data: any) => {
+                  respuesta = { ...respuesta, ...data }
+                },
+                error: (error: any) => console.log(error),
+                complete: () => {
+                  this.solicitudes_practicas.push(respuesta.body);
+                  console.log("Solicitudes de documentos de la practica:",this.solicitudes_practicas)
+                }
+              });
             });               
             console.log("Practicas correspondientes a nombre:",this.practicas_correspondiente_nombre)
           }

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -251,7 +251,7 @@
                                 <!-- Card Header - Accordion -->
                                 <a href="#collapseCardArchivos" class="d-block card-header py-3" data-toggle="collapse"
                                     role="button" aria-expanded="true" aria-controls="collapseCardArchivos">
-                                    <h6 class="m-0 font-weight-bold text-primary">Archivos Subidos</h6>
+                                    <h6 class="m-0 font-weight-bold text-primary">Solicitudes de Archivos</h6>
                                 </a>
                                 <!-- Card Content - Collapse -->
                                 <div class="collapse" id="collapseCardArchivos">
@@ -269,13 +269,16 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr *ngFor="let doc of documentos;">
-                                                            <td>{{doc.solicitud_documento.nombre_solicitud}}</td>
-                                                            <td>{{doc.solicitud_documento.tipo_archivo}}</td>
+                                                        <tr *ngFor="let solicitud of solicitudes_documentos;">
+                                                            <td>{{solicitud.nombre_solicitud}}</td>
+                                                            <td>{{solicitud.tipo_archivo}}</td>
                                                             <td>Normal</td>
-                                                            <!--add button that calls the function descargar documento with the parameter doc.key-->
                                                             <td><button class="btn btn-primary btn-sm btn-block"
-                                                                    (click)="descargar_documento(doc.id, doc_str)">Descargar</button>
+                                                                    *ngIf="solicitud.documentos.length != 0; else no_doc" 
+                                                                    (click)="descargar_documento(solicitud.documentos[0].id, doc_str)">Descargar</button>
+                                                                <ng-template #no_doc>
+                                                                    <b>No subido aún</b>
+                                                                </ng-template>
                                                             </td>
                                                         </tr>
                                                         <tr *ngFor="let doc_extra of documento_extras;">

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -23,7 +23,7 @@ export class DetallePracticaComponent implements OnInit {
   dtTrigger: Subject<any> = new Subject();
 
   practica: any = {};
-  documentos: any = [];
+  solicitudes_documentos: any = [];
   documento_extras: any = [];
   informes: any = [];
   evaluaciones: any = [];
@@ -77,15 +77,31 @@ export class DetallePracticaComponent implements OnInit {
           this.practica = respuesta.body;
           this.check_resumen();
 
-          //console.log("ID_ESTUDIANTE",this.id_estudiante)
-
           if (this.practica.estado == environment.estado_practica.evaluada ||
             this.practica.estado == environment.estado_practica.aprobada ||
             this.practica.estado == environment.estado_practica.reprobada) {
             this.botones_habilitados = true;
           }
 
-          this.documentos = this.practica.documentos;
+
+          //make request to get solicitudes documentos in /todos_docs_practica
+          this.service.obtener_solicitudes_documentos(this.practica.id, this.practica.modalidad.config_practica.id).subscribe({
+            next: (data: any) => {
+              respuesta = { ...respuesta, ...data }
+            },
+            error: (error: any) => {
+              this.solicitudes_documentos = [];
+              this._snackBar.open("Error al solicitar solicitudes de documentos", "Cerrar", {
+                duration: 10000,
+                panelClass: ['red-snackbar']
+              });
+            },
+            complete: () => {
+              this.solicitudes_documentos = respuesta.body;
+            }
+          });
+
+
           this.documento_extras = this.practica.documento_extras;
           this.informes = this.practica.informes;
           // considerar como evaluaciones todas las respuestas que tengan un tipo_respuesta que sea un número


### PR DESCRIPTION
Inicialmente, el problema era que en el detalle_practica del encargado se veían los documentos subidos por el estudiante y no todas las solicitudes. Eso se cambió y debería funcionar correctamente.

Después, se detectó un problema en la vista alumno, donde salía que un archivo todavía no subido por el alumno 2 ya había sido subido. Esto era porque estaba tomando el archivo de la práctica de otro alumno - no se diferenciaban los documentos que realmente estaban enlazados a la práctica. Esto también se debería haber solucionado.

REQUIERE LA ÚLTIMA VERSIÓN DEL DEV DEL BACKEND PARA FUNCIONAR

Para testear:
- Ver si, para un encargado, en la vista de detalle_practica, se ven todas las solicitudes de documentos creadas, y no sólo aquellas donde se hayan subido archivos. Para las que no se han subido, debería salir un texto indicando que no se ha subido aún.
- Para la vista alumno, debería salir correctamente que no ha subido archivos si es que no la ha hecho. 
- Subir un archivo en la vista alumno, y ver si se sube correctamente, y si el cambio se ve reflejado en la vista de encargado (debería permitir descargar ese archivo en ambas vistas)

Closes #122 