### PR TITLE
Fixeado bug de solicitudes de archivos poniendose en cualquier tabla

### DIFF
--- a/src/app/vistas/alumno/alumno.component.html
+++ b/src/app/vistas/alumno/alumno.component.html
@@ -235,7 +235,7 @@
                                                                                         </thead>
                                                                                         <tbody>
                                                                                             <tr
-                                                                                                *ngFor="let solicitud of solicitudes_practicas[i];">
+                                                                                                *ngFor="let solicitud of solicitudes_practicas[practica[1].id];">
                                                                                                 <td>{{solicitud?.nombre_solicitud}}
                                                                                                 </td>
                                                                                                 <td>{{solicitud?.tipo_archivo}}


### PR DESCRIPTION
Asociado a issue #206 
Esto concierne específicamente a las solicitudes normales y no a las solicitudes "extra".

Para probar:

-Verificar que en la vista de alumno se muestran las solicitudes de archivos en la tabla de la práctica que le corresponde.

-Al actualizar la página no deberían cambiarse de tabla las solicitudes creadas. 

-Se pueden crear nuevas solicitudes_documento en la bd, asociadas a un config_practica definido, y ver si estas solicitudes le aparecen al alumno en la tabla correspondiente. (Yo creé algunas solicitudes que tienen en su nombre el nombre de la config practica asociada, por ejemplo "archivo practica industrial", fáciles de verificar)

La solución fue reemplazar el uso de listas para las solicitudes (que se asumían en el mismo orden que las practicas), por un objeto json que tiene las solicitudes junto con el id de la práctica a la que corresponden.

