### PR TITLE
Fixes varios de chat y evaluacion supervisor

### DIFF
--- a/src/app/componentes/barra-superior/barra-superior.component.html
+++ b/src/app/componentes/barra-superior/barra-superior.component.html
@@ -114,7 +114,7 @@
                                     alt="...">
                                 <div class="status-indicator bg-success"></div>
                             </div>
-                            Encargado {{persona.usuario.nombre}}
+                            Encargado {{persona?.usuario?.nombre}}
                         </div>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
                                     alt="...">
                                 <div class="status-indicator bg-success"></div>
                             </div>
-                            Estudiante {{persona.usuario.nombre}}
+                            Estudiante {{persona?.usuario?.nombre}}
                             <div class="font-weight-bold"></div>
                         </div>
                     </div>

--- a/src/app/componentes/barra-superior/barra-superior.component.ts
+++ b/src/app/componentes/barra-superior/barra-superior.component.ts
@@ -115,16 +115,15 @@ export class BarraSuperiorComponent implements OnInit{
           return;
         },
         complete: () => {
-          if (this.respuesta.body[0].practicas.length == 0){
-            return;
-          }
-          for (let i = 0; i < this.respuesta.body[0].practicas.length; i++){
-            // check if the person is already in the list
-            if (!this.id_personas.includes(this.respuesta.body[0].practicas[i].id_encargado)){
-              this.id_personas.push(this.respuesta.body[0].practicas[i].id_encargado);
-              this.personas.push(this.respuesta.body[0].practicas[i].encargado);
+          //console.log("respuesta", this.respuesta)
+          
+          // Se muestran todos los encargados en la misma carrera que el estudiante
+          if (this.respuesta.body.hasOwnProperty("carrera") == true){
+            if (this.respuesta.body.carrera.hasOwnProperty("encargados") == true){
+              this.personas = this.respuesta.body.carrera.encargados;
             }
           }
+          
           this.respuesta = [];
           //console.log("ENCARGADOS:",this.personas);
         }
@@ -140,16 +139,17 @@ export class BarraSuperiorComponent implements OnInit{
           return;
         },
         complete: () => {
-          if (this.respuesta.body[0].practicas.length == 0){
-            return;
-          }
-          for (let i = 0; i < this.respuesta.body[0].practicas.length; i++){
-            if (!this.id_personas.includes(this.respuesta.body[0].practicas[i].id_estudiante)){
-              this.id_personas.push(this.respuesta.body[0].practicas[i].id_estudiante);
-              this.personas.push(this.respuesta.body[0].practicas[i].estudiante);
+          //console.log("respuesta", this.respuesta)
+          
+          // Se muestran todos los encargados en la misma carrera que el estudiante
+          if (this.respuesta.body.hasOwnProperty("carrera") == true){
+            if (this.respuesta.body.carrera.hasOwnProperty("estudiantes") == true){
+              this.personas = this.respuesta.body.carrera.estudiantes;
             }
           }
+          
           this.respuesta = [];
+          //console.log("ENCARGADOS:",this.personas);
         }
       })
     } 
@@ -293,13 +293,30 @@ export class BarraSuperiorComponent implements OnInit{
   redirect_to_chat(userid_otro_participante:number, tipo:string){
     
     if(tipo=="encargado"){
-      // reditect to url
-      //window.location.href = "/chat/sala"+userid_otro_participante+this.id_usuario+"/"+this.id_usuario+"/"+userid_otro_participante+"/encargado"
-      this.router.navigate(['/chat/sala'+userid_otro_participante+this.id_usuario+"/"+this.id_usuario+"/"+userid_otro_participante+"/encargado"]);
+      if (this.router.url.includes("chat/sala")){
+        this.router.navigate(['/chat/sala'+userid_otro_participante+this.id_usuario+"/"+this.id_usuario+"/"+userid_otro_participante+"/encargado"]);
+        // reload the page after 1 second
+        setTimeout(() => {
+          window.location.reload(); // esto es porque si ya se estaba en un chat, no recargaba los mensajes
+        }
+        , 300);
+      }
+      else{
+        this.router.navigate(['/chat/sala'+userid_otro_participante+this.id_usuario+"/"+this.id_usuario+"/"+userid_otro_participante+"/encargado"]);
+      }
     }
     else if(tipo=="estudiante"){
-      //window.location.href = "/chat/sala"+this.id_usuario+userid_otro_participante+"/"+this.id_usuario+"/"+userid_otro_participante+"/estudiante";
-      this.router.navigate(['/chat/sala'+this.id_usuario+userid_otro_participante+"/"+this.id_usuario+"/"+userid_otro_participante+"/estudiante"]);
+      if (this.router.url.includes("chat/sala")){
+        this.router.navigate(['/chat/sala'+this.id_usuario+userid_otro_participante+"/"+this.id_usuario+"/"+userid_otro_participante+"/estudiante"]);
+        // reload the page after 1 second
+        setTimeout(() => {
+          window.location.reload(); // esto es porque si ya se estaba en un chat, no recargaba los mensajes
+        }
+        , 300);
+      }
+      else{
+        this.router.navigate(['/chat/sala'+this.id_usuario+userid_otro_participante+"/"+this.id_usuario+"/"+userid_otro_participante+"/estudiante"]);
+      }
     }
   }
 

--- a/src/app/componentes/chat/chat.component.html
+++ b/src/app/componentes/chat/chat.component.html
@@ -24,14 +24,14 @@
                                     <div *ngFor = "let mensaje of Historial?.mensajes" [ngClass]="(mensaje.emisor=='estudiante')? 'enviado' : 'recibido'">
                                         <p class="texto" style="white-space: pre-line;">{{mensaje.texto}}</p>
                                         <!-- show fecha and parse the date and time-->
-                                        <p class="horafecha">Enviado: {{mensaje.fecha | date:'dd/MM/yyyy'}} a las {{mensaje.fecha | date:'HH:mm'}}</p>
+                                        <p class="horafecha">Enviado: {{mensaje?.fecha | date:'dd/MM/yyyy'}} a las {{mensaje?.fecha | date:'HH:mm'}}</p>
                                     </div>
                                 </div>
                                 <div class = "contenedordemensajes" *ngIf = "tipo == 'encargado'" >
                                     <div *ngFor = "let mensaje of Historial?.mensajes" [ngClass]="(mensaje.emisor=='encargado')? 'enviado' : 'recibido'">
                                         <p class="texto" style="white-space: pre-line;">{{mensaje.texto}}</p>
                                         <!-- show fecha and parse the date and time-->
-                                        <p class="horafecha">Enviado: {{mensaje.fecha | date:'dd/MM/yyyy'}} a las {{mensaje.fecha | date:'HH:mm'}}</p>
+                                        <p class="horafecha">Enviado: {{mensaje?.fecha | date:'dd/MM/yyyy'}} a las {{mensaje?.fecha | date:'HH:mm'}}</p>
                                     </div>
                                 </div>                                
                             </div>

--- a/src/app/componentes/chat/chat.component.ts
+++ b/src/app/componentes/chat/chat.component.ts
@@ -59,12 +59,6 @@ export class ChatComponent implements OnInit {
     this.router.params.subscribe(params => {this.Id2 = +params['id2'];});
     this.id_usuario = auth_user.userdata.id;
     this.router.params.subscribe(params => {this.tipo = params['tipo'];});
-
-    let id_aux = this.router.snapshot.queryParamMap.get('userid_otro_participante');
-    if(id_aux!=null){
-      this.userid_otro_participante = +id_aux;
-    }
-
     this.router.params.subscribe(params => {this.room = params['room'];}); 
 
     // check if the room is already set in the cookies, if it is destroy it
@@ -86,10 +80,12 @@ export class ChatComponent implements OnInit {
     if(this.tipo=="estudiante"){
       this.id_estudiante=this.Id;
       this.id_encargado=this.Id2;
+      this.userid_otro_participante = this.Id2;
     }
     else{
       this.id_encargado=this.Id;
       this.id_estudiante=this.Id2;
+      this.userid_otro_participante = this.Id;
     }
 
     this.service_obtener.obtener_estudiante(this.id_estudiante).subscribe({
@@ -101,7 +97,7 @@ export class ChatComponent implements OnInit {
         return;
       },
       complete:() => {
-        console.log(this.respuesta.body);
+        //console.log(this.respuesta.body);
         this.nombre_estudiante = this.respuesta.body.usuario.nombre;
         this.correo_estudiante = this.respuesta.body.usuario.correo;
         this.estado_config_estudiante = this.respuesta.body.usuario.config;
@@ -117,13 +113,12 @@ export class ChatComponent implements OnInit {
         return;
       },
       complete:() => {
-        console.log(this.respuesta.body);
+        //console.log(this.respuesta.body);
         this.nombre_encargado = this.respuesta.body.usuario.nombre
         this.correo_encargado = this.respuesta.body.usuario.correo;
         this.estado_config_encargado = this.respuesta.body.usuario.config;
       }
     })
-
     // buscar si chat existe en BD
     this.chatService.getchat(this.id_estudiante,this.id_encargado).subscribe({
       next: (data: any) => {
@@ -164,9 +159,9 @@ export class ChatComponent implements OnInit {
         }
       }
     });
-    
     // buscar datos del usuario otro participante
     if(this.userid_otro_participante!=-1){
+
       this.chatService.getusuario(this.userid_otro_participante).subscribe({
         next: (data: any) => {
           this.respuesta = { ...this.respuesta, ...data }
@@ -177,7 +172,7 @@ export class ChatComponent implements OnInit {
         },
         complete: () => {
           this.usuario_otro_participante = this.respuesta.body;
-          //console.log("Nombre del otro participante: ",this.usuario_otro_participante.nombre);
+          //console.log("Nombre del otro participante: ",this.usuario_otro_participante);
           this.cdr.detectChanges();
         }
       });
@@ -200,7 +195,7 @@ export class ChatComponent implements OnInit {
       },
       error: (error: any) => console.log("Error en enviar mensaje:",error),  
       complete: () =>{
-        console.log(this.tipo);
+        //console.log(this.tipo);
         let noti: string = "";
         if(mensaje.emisor == "encargado"){
           noti = "El encargado "+ this.nombre_encargado +" te ha enviado un mensaje"
@@ -255,6 +250,13 @@ export class ChatComponent implements OnInit {
 
   volver_atras(){
     window.history.back();
+    // if the previous url contains /chat/sala, reload the page after 300 miliseconds
+    setTimeout(() => {
+      if(window.location.href.includes("/chat/sala")){
+        window.location.reload(); // esto es porque si ya se estaba en un chat, no recargaba los mensajes
+      }
+    }
+    , 300);
   }
   
   ngAfterViewChecked() {

--- a/src/app/servicios/notis-chat/notis-chat.service.ts
+++ b/src/app/servicios/notis-chat/notis-chat.service.ts
@@ -33,7 +33,7 @@ export class NotisChatService extends Socket{
     
     if (cookie.check('room')){
       this.listen();
-      console.log("Conexion establecida en ROOM:", cookie.get('room'));
+      //console.log("Conexion establecida en ROOM:", cookie.get('room'));
     }
     else{
       console.log("Conexion no establecida con socketIO al no encontrarse room");
@@ -45,7 +45,7 @@ export class NotisChatService extends Socket{
   }
 
   emitEvent = (payload = {}) => {
-    console.log('emitiendo Evento', payload);
+    //console.log('emitiendo Evento', payload);
     this.ioSocket.emit('evento', payload)
   }
 
@@ -76,10 +76,7 @@ export class NotisChatService extends Socket{
   }
 
   getusuario(id_usuario:number){
-    console.log("id_usuario EN REQUEST", id_usuario);
     const req = new HttpRequest('GET', `${environment.url_back}/usuario/?id=${id_usuario}`);
     return this._http.request(req);
   }
-
-
 }


### PR DESCRIPTION
(Requiere rama de mismo nombre en backend)

Ahora se muestran, en el widget del chat (en la barra superior), todos los encargados o estudiantes de la misma carrera. 

Se fixearon problemas de carga de mensajes y de mostrar el nombre del otro participante en la vista del chat.

Ahora se procesan todas las respuestas de los informes del alumno cuando se van a hacer los cálculos de consistencia tras responder la encuesta de supervisor.

Cómo probar:

-Entrar con un alumno que no tenga prácticas inscritas.
-Ver al desplegar el widget de chat que se muestran todos los encargados de la misma carrera (debe haber al menos uno)

(Se puede hacer el mismo proceso desde un encargado)