### PR TITLE
Fix fragmentos sin respuesta abierta

### DIFF
--- a/src/app/componentes/fragmentos/fragmentos.component.ts
+++ b/src/app/componentes/fragmentos/fragmentos.component.ts
@@ -10,7 +10,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class FragmentosComponent {
   id_practica: number;
-  fragmentos_informes: string[][];
+  fragmentos_informes: string[][] = [];
   fragmentos_supervisor: string[][];
 
   getFragmentosTexto() {
@@ -62,6 +62,9 @@ export class FragmentosComponent {
 
 
       }, error: (error) => {
+        if (error.status == 404) {
+          return;
+        }
         this._snackBar.open("Error al recolectar los fragmentos", "Cerrar", {
           panelClass: ['red-snackbar'],
           duration: 3000

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -374,24 +374,31 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr *ngFor="let resp of respuestas_sup_parsed;">
-                                                            <td style="vertical-align: middle;">{{resp[1]}}</td>
-                                                            <td *ngIf="resp[0];else textoSolo"
-                                                                style="vertical-align: middle;">
-                                                                {{resp[2]}}
-                                                            </td>
-                                                            <ng-template #textoSolo style="vertical-align: middle;">
-                                                                <td style="vertical-align: middle;">
-                                                                    {{resp[2][0]}}
-                                                                    <span class="bg-gradient-success"
-                                                                        style="vertical-align: middle;">
-                                                                        {{resp[2][1]}}
-                                                                    </span>
-                                                                    {{resp[2][2]}}
-                                                                </td>
-                                                            </ng-template>
-
+                                                        <tr
+                                                            *ngIf="!respuestas_sup_parsed || respuestas_sup_parsed.length<1; else sin_respuestas_abiertas">
+                                                            <td colspan="2" class="text-center">Sin Respuesta</td>
                                                         </tr>
+                                                        <ng-template #sin_respuestas_abiertas>
+                                                            <tr *ngFor="let resp of respuestas_sup_parsed;">
+                                                                <td style="vertical-align: middle;">{{resp[1]}}</td>
+                                                                <td *ngIf="resp[0];else textoSolo"
+                                                                    style="vertical-align: middle;">
+                                                                    {{resp[2]}}
+                                                                </td>
+                                                                <ng-template #textoSolo style="vertical-align: middle;">
+                                                                    <td style="vertical-align: middle;">
+                                                                        {{resp[2][0]}}
+                                                                        <span class="bg-gradient-success"
+                                                                            style="vertical-align: middle;">
+                                                                            {{resp[2][1]}}
+                                                                        </span>
+                                                                        {{resp[2][2]}}
+                                                                    </td>
+                                                                </ng-template>
+
+                                                            </tr>
+                                                        </ng-template>
+
                                                     </tbody>
                                                 </table>
                                             </div>
@@ -474,7 +481,7 @@
                                                             width="100%" cellspacing="0">
                                                             <thead>
                                                                 <tr>
-                                                                    <th>Textos más relevantes del Alumno</th>
+                                                                    <th>Resumen de el/los informe/s del Alumno</th>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
@@ -488,7 +495,19 @@
                                                                     </td>
                                                                     <ng-template #resumen1>
                                                                         <td id="resumen_informes">
-                                                                            {{practica.resumen.informe}}
+
+                                                                            <div
+                                                                                *ngIf="!practica.resumen || !practica.resumen.informe || practica.resumen.informe=='' ; else hay_resumen_alumno">
+                                                                                <div>
+                                                                                    No hay resumen disponible
+                                                                                </div>
+                                                                            </div>
+                                                                            <ng-template #hay_resumen_alumno>
+                                                                                <div>
+                                                                                    {{practica.resumen.informe}}
+                                                                                </div>
+                                                                            </ng-template>
+
                                                                         </td>
                                                                     </ng-template>
 
@@ -507,7 +526,7 @@
                                                             width="100%" cellspacing="0">
                                                             <thead>
                                                                 <tr>
-                                                                    <th>Textos más relevantes del Supervisor</th>
+                                                                    <th>Resumen del informe del supervisor</th>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
@@ -523,7 +542,17 @@
                                                                     </td>
                                                                     <ng-template #resumen2>
                                                                         <td id="resumen_supervisor">
-                                                                            {{practica.resumen.supervisor}}
+                                                                            <div
+                                                                                *ngIf="!practica.resumen || !practica.resumen.supervisor || practica.resumen.supervisor=='' ; else hay_resumen_supervisor">
+                                                                                <div>
+                                                                                    No hay resumen disponible
+                                                                                </div>
+                                                                            </div>
+                                                                            <ng-template #hay_resumen_supervisor>
+                                                                                <div>
+                                                                                    {{practica.resumen.supervisor}}
+                                                                                </div>
+                                                                            </ng-template>
                                                                         </td>
                                                                     </ng-template>
                                                                 </tr>

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -122,7 +122,7 @@ export class DetallePracticaComponent implements OnInit {
 
           this.practica.consistencia_nota = this.practica.consistencia_nota ? `${Math.round(100 * this.practica.consistencia_nota)}%` : "—";
           this.practica.consistencia_informe = this.practica.consistencia_informe ? `${Math.round(100 * this.practica.consistencia_informe)}%` : "—";
-          
+
 
           //make request to get solicitudes documentos in /todos_docs_practica
           this.service.obtener_solicitudes_documentos(this.practica.id, this.practica.modalidad.config_practica.id).subscribe({


### PR DESCRIPTION
Se prueba con una rama en backend del mismo nombre.

Hay que entrar a una práctica que no tenga resumen ni key_fragmentos (se pueden borrar a mano) y debería decir que no hay fragmentos y al generar el resumen debería dar un resumen o decir que no hay resumen disponible
