### PR TITLE
Fixeando issues varios en detalle práctica, resumen prácticas (encargado), y otras cosas

### DIFF
--- a/src/app/componentes/barra-superior/barra-superior.component.html
+++ b/src/app/componentes/barra-superior/barra-superior.component.html
@@ -101,11 +101,11 @@
                 <span class="badge badge-danger badge-counter"></span>
             </a>
             <!-- Dropdown - Messages -->
-            <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
+            <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in chatWidget"
                 aria-labelledby="messagesDropdown">
                 
                 <div *ngIf = "es_alumno == 1; else elseblock">
-                    <h6 class="dropdown-header">Encargados disponibles</h6>
+                    <h6 class="dropdown-header fixed-header">Encargados disponibles</h6>
                     <p style="margin-left: 5%; margin-top: 4%;"></p>
                     <div *ngFor = "let persona of personas">
                         <div class="dropdown-item d-flex align-items-center" (click)="redirect_to_chat(persona.usuario.id, 'estudiante')">
@@ -120,7 +120,7 @@
                 </div>
 
                 <ng-template #elseblock>
-                    <h6 class="dropdown-header">Alumnos disponibles</h6>
+                    <h6 class="dropdown-header fixed-header">Alumnos disponibles</h6>
                     <div *ngFor = "let persona of personas">
                         <div class="dropdown-item d-flex align-items-center" (click)="redirect_to_chat(persona.usuario.id, 'encargado')" >
                             <div class="dropdown-list-image mr-3">
@@ -133,7 +133,7 @@
                         </div>
                     </div>
                 </ng-template>
-                <a class="dropdown-item text-center small text-gray-500" href="#">Más mensajes</a>
+                <!--<a class="dropdown-item text-center small text-gray-500" href="#">Más mensajes</a>-->
             </div>
         </li>
 

--- a/src/app/componentes/barra-superior/barra-superior.component.scss
+++ b/src/app/componentes/barra-superior/barra-superior.component.scss
@@ -9,3 +9,7 @@
     background-color: #fff; /* Set a background color to match your design */
     z-index: 1;
 }
+
+.navbar {
+    height: 60px
+}

--- a/src/app/componentes/barra-superior/barra-superior.component.scss
+++ b/src/app/componentes/barra-superior/barra-superior.component.scss
@@ -1,0 +1,11 @@
+.chatWidget {
+    max-height: 500px;
+    overflow: auto;
+}
+
+.fixed-header {
+    position: sticky;
+    top: 0;
+    background-color: #fff; /* Set a background color to match your design */
+    z-index: 1;
+}

--- a/src/app/componentes/revision/revision.component.html
+++ b/src/app/componentes/revision/revision.component.html
@@ -1,14 +1,14 @@
 <div *ngIf="this.cambiar_estado; else botonCambiarEstado" class="container">
-    <button class="btn btn-success btn-md ml-1 mr-1 mt-1 mb-1"  (click)="aprobar(1)">Aprobar</button>
-    <button class="btn btn-danger btn-md ml-1 mr-1 mt-1 mb-1" (click)="aprobar(0)">Reprobar</button>
+    <button class="btn btn-success btn-sm ml-1 mr-1 mt-1 mb-1 revisionBtn"  (click)="aprobar(1)">Aprobar</button>
+    <button class="btn btn-danger btn-sm ml-1 mr-1 mt-1 mb-1 revisionBtn" (click)="aprobar(0)">Reprobar</button>
 </div>
 <ng-template #botonCambiarEstado>
     <div class="container" *ngIf="this.estado_practica=='Aprobada'; else cambiarAAprobada">
-        <button class="btn btn-secondary ml-1 mr-1 mt-1 mb-1"  (click)="aprobar(0)">Cambiar a "Reprobada"</button>
+        <button class="btn btn-secondary btn-sm ml-1 mr-1 mt-1 mb-1"  (click)="aprobar(0)">Cambiar a "Reprobada"</button>
     </div>
     <ng-template #cambiarAAprobada>
         <div class="container">
-            <button class="btn btn-secondary btn-md ml-1 mr-1 mt-1 mb-1"  (click)="aprobar(1)">Cambiar a "Aprobada"</button>
+            <button class="btn btn-secondary btn-sm ml-1 mr-1 mt-1 mb-1"  (click)="aprobar(1)">Cambiar a "Aprobada"</button>
         </div>
     </ng-template>
 </ng-template>

--- a/src/app/componentes/revision/revision.component.scss
+++ b/src/app/componentes/revision/revision.component.scss
@@ -5,3 +5,7 @@
     color: #f0fff3;
     background-color: #155724;
 }
+
+.revisionBtn {
+   width: 77px;
+}

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -151,7 +151,7 @@
                     <!-- Fila de Información general y Archivos -->
                     <div class="row">
                         <!-- Tarjeta Información general -->
-                        <div class="col-lg-12">
+                        <div class="col-lg-6">
                             <div class="card shadow mb-4">
                                 <!-- Card Header - Accordion -->
                                 <a href="#collapseCardGeneral" class="d-block card-header py-3" data-toggle="collapse"
@@ -167,13 +167,8 @@
                                             </div>
                                             <div class="col-6">
                                                 {{ practica?.estudiante?.usuario.correo }}
-                                            </div>
-                                            <div class="col-6">
-                                                Correo Supervisor:
-                                            </div>
-                                            <div class="col-6">
-                                                {{ practica?.supervisor?.correo }}
-                                            </div>
+                                            </div>                                            
+                                            
                                             <div class="col-6">
                                                 Horas Trabajadas:
                                             </div>
@@ -200,6 +195,40 @@
                                 </div>
                             </div>
                         </div><!-- Fin Tarjeta Información general -->
+
+                        <!-- Tarjeta Información Empresa -->
+                        <div class="col-lg-6">
+                            <div class="card shadow mb-4">
+                                <!-- Card Header - Accordion -->
+                                <a href="#collapseCardEmpresa" class="d-block card-header py-3" data-toggle="collapse"
+                                    role="button" aria-expanded="true" aria-controls="collapseCardEmpresa">
+                                    <h6 class="m-0 font-weight-bold text-primary">Información Empresa</h6>
+                                </a>
+                                <!-- Card Content - Collapse -->
+                                <div class="collapse show" id="collapseCardEmpresa">
+                                    <div class="card-body">
+                                        <div class="row">
+                                            <div class="col-6">                                                
+                                                Correo Supervisor:
+                                            </div>
+                                            <div class="col-6">
+                                                {{ practica?.supervisor?.correo }}
+                                            </div>
+                                            <div class="col-6">                                                
+                                                ¿Empresa verificada?:
+                                            </div>
+                                            <div class="col-6">
+                                                <i *ngIf="practica?.empresa?.empresa_verificada" title="Empresa verificada"
+                                                    class="fa-solid fa-check"></i>
+                                                <i *ngIf="!practica?.empresa?.empresa_verificada" title="Empresa no verificada"
+                                                    class="fa-solid fa-times"></i>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div><!-- Fin Tarjeta Información Empresa -->
+
                     </div><!-- Fin Fila -->
 
                     <div class="row">

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -251,7 +251,7 @@
                                                         <tr>
                                                             <th>Tipo</th>
                                                             <th>Horas Trabajadas</th>
-                                                            <th>Fecha Subido</th>
+                                                            <th>Fecha</th>
                                                             <th>Ver Informe</th>
                                                         </tr>
                                                     </thead>
@@ -260,7 +260,7 @@
                                                             <td>{{ informe.config_informe.tipo_informe }}</td>
                                                             <td>{{ informe.horas_trabajadas }}</td>
                                                             <td>{{ informe.fecha | date: 'dd/MM/yyyy' }}</td>
-                                                            <td>
+                                                            <td *ngIf="informe.key != null && !isDataEmpty(informe.key); else informeNoRespondido">
                                                                 <a class="nostyle"
                                                                     href="/informe/{{practica.id}}/{{informe.id}}">
                                                                     <button class="btn btn-primary btn-sm btn-block">
@@ -268,6 +268,11 @@
                                                                     </button>
                                                                 </a>
                                                             </td>
+                                                            <ng-template #informeNoRespondido>
+                                                                <td>
+                                                                    No subido aún
+                                                                </td>
+                                                            </ng-template>
                                                         </tr>                                                        
                                                     </tbody>
                                                 </table>

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -216,7 +216,7 @@
                                     <div class="card-body">
                                         <div class="overflow-auto">
                                             <div class="table-responsive ">
-                                                <table class="table table-bordered hoverTable" id="dataTable"
+                                                <table class="table table-bordered hoverTable" id="dataTable" *ngIf="informes.length>0; else noHayInformes"
                                                     width="100%" cellspacing="0">
                                                     <thead>
                                                         <tr>
@@ -227,28 +227,26 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <div *ngIf="informes.length>0; else noHayInformes" >
-                                                            <tr *ngFor="let informe of informes;">
-                                                                <td>{{ informe.config_informe.tipo_informe }}</td>
-                                                                <td>{{ informe.horas_trabajadas }}</td>
-                                                                <td>{{ informe.fecha | date: 'dd/MM/yyyy' }}</td>
-                                                                <td>
-                                                                    <a class="nostyle"
-                                                                        href="/informe/{{practica.id}}/{{informe.id}}">
-                                                                        <button class="btn btn-primary btn-sm btn-block">
-                                                                            Ver Informe
-                                                                        </button>
-                                                                    </a>
-                                                                </td>
-                                                            </tr>
-                                                        </div>
-                                                        <ng-template #noHayInformes>
-                                                            <tr>
-                                                                <td colspan="4" class="text-center">No hay informes asociados a esta práctica.</td>
-                                                            </tr>
-                                                        </ng-template>
+                                                        <tr *ngFor="let informe of informes;">
+                                                            <td>{{ informe.config_informe.tipo_informe }}</td>
+                                                            <td>{{ informe.horas_trabajadas }}</td>
+                                                            <td>{{ informe.fecha | date: 'dd/MM/yyyy' }}</td>
+                                                            <td>
+                                                                <a class="nostyle"
+                                                                    href="/informe/{{practica.id}}/{{informe.id}}">
+                                                                    <button class="btn btn-primary btn-sm btn-block">
+                                                                        Ver Informe
+                                                                    </button>
+                                                                </a>
+                                                            </td>
+                                                        </tr>                                                        
                                                     </tbody>
                                                 </table>
+                                                <ng-template #noHayInformes>
+                                                    <tr>
+                                                        <td colspan="4" class="text-center">No hay informes asociados a esta práctica.</td>
+                                                    </tr>
+                                                </ng-template>
                                             </div>
                                         </div>
                                     </div>
@@ -269,8 +267,8 @@
                                     <div class="card-body">
                                         <div class="overflow-auto">
                                             <div class="table-responsive">
-                                                <table class="table table-bordered hoverTable" id="dataTable"
-                                                    width="100%" cellspacing="0">
+                                                <table class="table table-bordered hoverTable" id="dataTable" width="100%" cellspacing="0"
+                                                *ngIf="solicitudes_documentos.length>0 || documento_extras.length>0; else noHaySolicitudes">
                                                     <thead>
                                                         <tr>
                                                             <th>Archivo</th>
@@ -280,40 +278,38 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <div *ngIf="solicitudes_documentos.length>0 || documento_extras.length>0; else noHaySolicitudes">
-                                                            <tr *ngFor="let solicitud of solicitudes_documentos;">
-                                                                <td>{{solicitud.nombre_solicitud}}</td>
-                                                                <td>{{solicitud.tipo_archivo}}</td>
-                                                                <td>Normal</td>
-                                                                <td><button class="btn btn-primary btn-sm btn-block"
-                                                                        *ngIf="solicitud.documentos.length != 0; else no_doc"
-                                                                        (click)="descargar_documento(solicitud.documentos[0].id, doc_str)">Descargar</button>
-                                                                    <ng-template #no_doc>
-                                                                        <b>No subido aún</b>
-                                                                    </ng-template>
-                                                                </td>
-                                                            </tr>
-                                                            <tr *ngFor="let doc_extra of documento_extras;">
-                                                                <td>{{doc_extra.nombre_solicitud}}</td>
-                                                                <td>{{doc_extra.tipo_archivo}}</td>
-                                                                <td>Extra</td>
-                                                                <td><button
-                                                                        *ngIf="doc_extra.key!=null && doc_extra.key!=''; else no_doc_extra"
-                                                                        class="btn btn-primary btn-sm btn-block"
-                                                                        (click)="descargar_documento(doc_extra.id, doc_extra_str)">Descargar</button>
-                                                                    <ng-template #no_doc_extra>
-                                                                        <b>No subido aún</b>
-                                                                    </ng-template>
-                                                                </td>
-                                                            </tr>
-                                                        </div>
-                                                        <ng-template #noHaySolicitudes>
-                                                            <tr>
-                                                                <td colspan="4" class="text-center">No hay solicitudes de archivos asociadas a esta práctica.</td>
-                                                            </tr>
-                                                        </ng-template>
+                                                        <tr *ngFor="let solicitud of solicitudes_documentos;">
+                                                            <td>{{solicitud.nombre_solicitud}}</td>
+                                                            <td>{{solicitud.tipo_archivo}}</td>
+                                                            <td>Normal</td>
+                                                            <td><button class="btn btn-primary btn-sm btn-block"
+                                                                    *ngIf="solicitud.documentos.length != 0; else no_doc"
+                                                                    (click)="descargar_documento(solicitud.documentos[0].id, doc_str)">Descargar</button>
+                                                                <ng-template #no_doc>
+                                                                    <b>No subido aún</b>
+                                                                </ng-template>
+                                                            </td>
+                                                        </tr>
+                                                        <tr *ngFor="let doc_extra of documento_extras;">
+                                                            <td>{{doc_extra.nombre_solicitud}}</td>
+                                                            <td>{{doc_extra.tipo_archivo}}</td>
+                                                            <td>Extra</td>
+                                                            <td><button
+                                                                    *ngIf="doc_extra.key!=null && doc_extra.key!=''; else no_doc_extra"
+                                                                    class="btn btn-primary btn-sm btn-block"
+                                                                    (click)="descargar_documento(doc_extra.id, doc_extra_str)">Descargar</button>
+                                                                <ng-template #no_doc_extra>
+                                                                    <b>No subido aún</b>
+                                                                </ng-template>
+                                                            </td>
+                                                        </tr>
                                                     </tbody>
                                                 </table>
+                                                <ng-template #noHaySolicitudes>
+                                                    <tr>
+                                                        <td colspan="4" class="text-center">No hay solicitudes de archivos asociadas a esta práctica.</td>
+                                                    </tr>
+                                                </ng-template>
                                             </div>
                                         </div>
                                     </div>
@@ -338,7 +334,7 @@
                                     <div class="card-body">
                                         <div class="overflow-auto">
                                             <div class="table-responsive">
-                                                <table class="table table-bordered hoverTable" id="dataTable"
+                                                <table class="table table-bordered hoverTable" id="dataTable" *ngIf="hay_respuesta == 1; else noHayRespuesta"
                                                     width="100%" cellspacing="0">
                                                     <thead>
                                                         <tr>
@@ -347,24 +343,21 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <div *ngIf="hay_respuesta == 1; else noHayRespuesta">
-                                                            <tr
-                                                                *ngFor="let aptitud of aptitudes_practica[0]; let j = index">
-                                                                <th>{{aptitud}}</th>
-                                                                <th>{{notas_aptitudes[0][j]}}</th>
-                                                            </tr>
-                                                            <tr>
-                                                                <th>Promedio</th>
-                                                                <th>{{promedio}}</th>
-                                                            </tr>
-                                                        </div>
-                                                        <ng-template #noHayRespuesta>
-                                                            <tr>
-                                                                <td colspan="2" class="text-center">El supervisor no ha evaluado esta práctica.</td>
-                                                            </tr>
-                                                        </ng-template>
+                                                        <tr *ngFor="let aptitud of aptitudes_practica[0]; let j = index">
+                                                            <th>{{aptitud}}</th>
+                                                            <th>{{notas_aptitudes[0][j]}}</th>
+                                                        </tr>
+                                                        <tr>
+                                                            <th>Promedio</th>
+                                                            <th>{{promedio}}</th>
+                                                        </tr>                                                     
                                                     </tbody>
                                                 </table>
+                                                <ng-template #noHayRespuesta>
+                                                    <tr>
+                                                        <td colspan="2" class="text-center">El supervisor no ha evaluado esta práctica.</td>
+                                                    </tr>
+                                                </ng-template>
                                             </div>
                                         </div>
                                     </div>
@@ -456,7 +449,7 @@
                     <div class="row">
                         <!-- Tarjeta Consistencia -->
                         <div class="col-lg-12">
-                            <div class="card shadow mb-4">
+                            <div class="card shadow mb-4" style="max-height: 500px; overflow:auto">
                                 <!-- Card Header - Accordion -->
                                 <a href="#collapseCardConsistencias" class="d-block card-header py-3"
                                     data-toggle="collapse" role="button" aria-expanded="true"
@@ -466,7 +459,7 @@
                                 <!-- Card Content - Collapse -->
                                 <div class="collapse show" id="collapseCardConsistencias">
                                     <div class="card-body">
-                                        <div class="overflow-auto_consistencia">
+                                        <div>
                                             <!-- tarjetas internas consistencia_informe y consistencia_nota-->
                                             <div class="row" style="max-width: 100%;">
                                                 <div class="col-xl-3"></div>
@@ -541,7 +534,7 @@
                                                                                 </div>
                                                                             </div>
                                                                             <ng-template #hay_resumen_alumno>
-                                                                                <div>
+                                                                                <div style="max-height: 200px; overflow: auto;">
                                                                                     {{practica.resumen.informe}}
                                                                                 </div>
                                                                             </ng-template>

--- a/src/app/vistas/detalle-practica/detalle-practica.component.html
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.html
@@ -71,8 +71,8 @@
                                             <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
                                                 Empresa</div>
                                             <div
-                                                [class]="!practica?.empresa.empresa_verificada? 'bg-warning h5 mb-0 font-weight-bold text-gray-800' : 'h5 mb-0 font-weight-bold text-gray-800'">
-                                                <i *ngIf="!practica?.empresa.empresa_verificada"
+                                                [class]="!practica?.empresa?.empresa_verificada? 'bg-warning h5 mb-0 font-weight-bold text-gray-800' : 'h5 mb-0 font-weight-bold text-gray-800'">
+                                                <i *ngIf="!practica?.empresa?.empresa_verificada"
                                                     title="Empresa no verificada"
                                                     class="fa-solid fa-triangle-exclamation"></i>{{
                                                 practica?.empresa?.nombre_empresa }}
@@ -227,19 +227,26 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr *ngFor="let informe of informes;">
-                                                            <td>{{ informe.config_informe.tipo_informe }}</td>
-                                                            <td>{{ informe.horas_trabajadas }}</td>
-                                                            <td>{{ informe.fecha | date: 'dd/MM/yyyy' }}</td>
-                                                            <td>
-                                                                <a class="nostyle"
-                                                                    href="/informe/{{practica.id}}/{{informe.id}}">
-                                                                    <button class="btn btn-primary btn-sm btn-block">
-                                                                        Ver Informe
-                                                                    </button>
-                                                                </a>
-                                                            </td>
-                                                        </tr>
+                                                        <div *ngIf="informes.length>0; else noHayInformes" >
+                                                            <tr *ngFor="let informe of informes;">
+                                                                <td>{{ informe.config_informe.tipo_informe }}</td>
+                                                                <td>{{ informe.horas_trabajadas }}</td>
+                                                                <td>{{ informe.fecha | date: 'dd/MM/yyyy' }}</td>
+                                                                <td>
+                                                                    <a class="nostyle"
+                                                                        href="/informe/{{practica.id}}/{{informe.id}}">
+                                                                        <button class="btn btn-primary btn-sm btn-block">
+                                                                            Ver Informe
+                                                                        </button>
+                                                                    </a>
+                                                                </td>
+                                                            </tr>
+                                                        </div>
+                                                        <ng-template #noHayInformes>
+                                                            <tr>
+                                                                <td colspan="4" class="text-center">No hay informes asociados a esta práctica.</td>
+                                                            </tr>
+                                                        </ng-template>
                                                     </tbody>
                                                 </table>
                                             </div>
@@ -273,31 +280,38 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr *ngFor="let solicitud of solicitudes_documentos;">
-                                                            <td>{{solicitud.nombre_solicitud}}</td>
-                                                            <td>{{solicitud.tipo_archivo}}</td>
-                                                            <td>Normal</td>
-                                                            <td><button class="btn btn-primary btn-sm btn-block"
-                                                                    *ngIf="solicitud.documentos.length != 0; else no_doc"
-                                                                    (click)="descargar_documento(solicitud.documentos[0].id, doc_str)">Descargar</button>
-                                                                <ng-template #no_doc>
-                                                                    <b>No subido aún</b>
-                                                                </ng-template>
-                                                            </td>
-                                                        </tr>
-                                                        <tr *ngFor="let doc_extra of documento_extras;">
-                                                            <td>{{doc_extra.nombre_solicitud}}</td>
-                                                            <td>{{doc_extra.tipo_archivo}}</td>
-                                                            <td>Extra</td>
-                                                            <td><button
-                                                                    *ngIf="doc_extra.key!=null && doc_extra.key!=''; else no_doc_extra"
-                                                                    class="btn btn-primary btn-sm btn-block"
-                                                                    (click)="descargar_documento(doc_extra.id, doc_extra_str)">Descargar</button>
-                                                                <ng-template #no_doc_extra>
-                                                                    <b>No subido aún</b>
-                                                                </ng-template>
-                                                            </td>
-                                                        </tr>
+                                                        <div *ngIf="solicitudes_documentos.length>0 || documento_extras.length>0; else noHaySolicitudes">
+                                                            <tr *ngFor="let solicitud of solicitudes_documentos;">
+                                                                <td>{{solicitud.nombre_solicitud}}</td>
+                                                                <td>{{solicitud.tipo_archivo}}</td>
+                                                                <td>Normal</td>
+                                                                <td><button class="btn btn-primary btn-sm btn-block"
+                                                                        *ngIf="solicitud.documentos.length != 0; else no_doc"
+                                                                        (click)="descargar_documento(solicitud.documentos[0].id, doc_str)">Descargar</button>
+                                                                    <ng-template #no_doc>
+                                                                        <b>No subido aún</b>
+                                                                    </ng-template>
+                                                                </td>
+                                                            </tr>
+                                                            <tr *ngFor="let doc_extra of documento_extras;">
+                                                                <td>{{doc_extra.nombre_solicitud}}</td>
+                                                                <td>{{doc_extra.tipo_archivo}}</td>
+                                                                <td>Extra</td>
+                                                                <td><button
+                                                                        *ngIf="doc_extra.key!=null && doc_extra.key!=''; else no_doc_extra"
+                                                                        class="btn btn-primary btn-sm btn-block"
+                                                                        (click)="descargar_documento(doc_extra.id, doc_extra_str)">Descargar</button>
+                                                                    <ng-template #no_doc_extra>
+                                                                        <b>No subido aún</b>
+                                                                    </ng-template>
+                                                                </td>
+                                                            </tr>
+                                                        </div>
+                                                        <ng-template #noHaySolicitudes>
+                                                            <tr>
+                                                                <td colspan="4" class="text-center">No hay solicitudes de archivos asociadas a esta práctica.</td>
+                                                            </tr>
+                                                        </ng-template>
                                                     </tbody>
                                                 </table>
                                             </div>
@@ -321,7 +335,7 @@
                                 <!-- Card Content - Collapse -->
                                 <div class="collapse show" id="collapseCardEvaluacion">
                                     <!-- Evaluación de Aptitudes -->
-                                    <div class="card-body" *ngIf="hay_respuesta == 1">
+                                    <div class="card-body">
                                         <div class="overflow-auto">
                                             <div class="table-responsive">
                                                 <table class="table table-bordered hoverTable" id="dataTable"
@@ -333,15 +347,22 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr
-                                                            *ngFor="let aptitud of aptitudes_practica[0]; let j = index">
-                                                            <th>{{aptitud}}</th>
-                                                            <th>{{notas_aptitudes[0][j]}}</th>
-                                                        </tr>
-                                                        <tr>
-                                                            <th>Promedio</th>
-                                                            <th>{{promedio}}</th>
-                                                        </tr>
+                                                        <div *ngIf="hay_respuesta == 1; else noHayRespuesta">
+                                                            <tr
+                                                                *ngFor="let aptitud of aptitudes_practica[0]; let j = index">
+                                                                <th>{{aptitud}}</th>
+                                                                <th>{{notas_aptitudes[0][j]}}</th>
+                                                            </tr>
+                                                            <tr>
+                                                                <th>Promedio</th>
+                                                                <th>{{promedio}}</th>
+                                                            </tr>
+                                                        </div>
+                                                        <ng-template #noHayRespuesta>
+                                                            <tr>
+                                                                <td colspan="2" class="text-center">El supervisor no ha evaluado esta práctica.</td>
+                                                            </tr>
+                                                        </ng-template>
                                                     </tbody>
                                                 </table>
                                             </div>
@@ -377,7 +398,7 @@
                                                     <tbody>
                                                         <tr
                                                             *ngIf="!respuestas_sup_parsed || respuestas_sup_parsed.length<1; else sin_respuestas_abiertas">
-                                                            <td colspan="2" class="text-center">Sin Respuesta</td>
+                                                            <td colspan="2" class="text-center">El supervisor no ha hecho comentarios sobre esta práctica.</td>
                                                         </tr>
                                                         <ng-template #sin_respuestas_abiertas>
                                                             <tr *ngFor="let resp of respuestas_sup_parsed;">

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -112,6 +112,7 @@ export class DetallePracticaComponent implements OnInit {
         },
         complete: () => {
           this.practica = respuesta.body;
+          //console.log(this.practica);
           this.check_resumen();
 
           if(this.practica.ev_encargado==null){
@@ -208,21 +209,21 @@ export class DetallePracticaComponent implements OnInit {
                 }
               }
               respuestas_traducidas = respuestas_traducidas.slice(0, -2);
-              console.log(respuestas_traducidas);
+              //console.log(respuestas_traducidas);
               this.respuestas_supervisor[i].respuesta = respuestas_traducidas;
             }
           }
 
           if(this.practica.informes.length > 0){
-            console.log(this.practica.informes[0].key)
+            //console.log(this.practica.informes[0].key)
 
             //respuestas preguntas
             let lista_informes = Object.values(this.practica.informes[0].key)
-            console.log(lista_informes)
+            //console.log(lista_informes)
 
             //id preguntas
             let keys = Object.keys(this.practica.informes[0].key)
-            console.log(keys)
+            //console.log(keys)
 
             let preguntas_informe: any = []
 
@@ -243,7 +244,7 @@ export class DetallePracticaComponent implements OnInit {
 
                   if (i == keys.length - 1) {
 
-                    console.log(preguntas_informe)
+                    //console.log(preguntas_informe)
                     //console.log(preguntas_informe.length)
 
                     //orednar preguntas informe
@@ -257,8 +258,8 @@ export class DetallePracticaComponent implements OnInit {
                       }
                     }
 
-                    console.log("preguntas informe ordenadas")
-                    console.log(preguntas_informe_ordenadas)
+                    //console.log("preguntas informe ordenadas")
+                    //console.log(preguntas_informe_ordenadas)
 
                     let preguntas_respuestas_informes_aux = []
 
@@ -267,8 +268,8 @@ export class DetallePracticaComponent implements OnInit {
                       preguntas_respuestas_informes_aux.push(lista_informes[i])
                     }
 
-                    console.log("preguntas_respuestas_informes")
-                    console.log(preguntas_respuestas_informes_aux)
+                    //console.log("preguntas_respuestas_informes")
+                    //console.log(preguntas_respuestas_informes_aux)
 
                     this.preguntas_respuestas_informe = preguntas_respuestas_informes_aux
 
@@ -344,7 +345,7 @@ export class DetallePracticaComponent implements OnInit {
         data = { ...data, ..._data };
       },
       complete: () => {
-        console.log(data.body)
+        //console.log(data.body)
         if (!data.body) {
           this._snackBar.open("Error al solicitar resumen, por favor vuelva más tarde", "Cerrar", {
             panelClass: ['red-snackbar'],
@@ -447,7 +448,7 @@ export class DetallePracticaComponent implements OnInit {
 
     //console.log(keys)
 
-    console.log(this.preguntas_respuestas_informe)
+    //console.log(this.preguntas_respuestas_informe)
 
     for (let i = 0; i < this.preguntas_respuestas_informe.length; i++) {
       var palabras_informe = this.preguntas_respuestas_informe[i].split(" ")
@@ -685,7 +686,7 @@ export class DetallePracticaComponent implements OnInit {
             return;
           },
           complete: () => {
-            console.log("Notificación enviada con éxito");
+            //console.log("Notificación enviada con éxito");
             window.location.reload()
           }
         });

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -213,73 +213,71 @@ export class DetallePracticaComponent implements OnInit {
             }
           }
 
-          console.log(this.practica.informes[0].key)
+          if(this.practica.informes.length > 0){
+            console.log(this.practica.informes[0].key)
 
-          //respuestas preguntas
-          let lista_informes = Object.values(this.practica.informes[0].key)
-          console.log(lista_informes)
+            //respuestas preguntas
+            let lista_informes = Object.values(this.practica.informes[0].key)
+            console.log(lista_informes)
 
-          //id preguntas
-          let keys = Object.keys(this.practica.informes[0].key)
-          console.log(keys)
+            //id preguntas
+            let keys = Object.keys(this.practica.informes[0].key)
+            console.log(keys)
 
-          let preguntas_informe: any = []
+            let preguntas_informe: any = []
 
-          for (let i = 0; i < keys.length; i++) {
-            this.service_informe.get_pregunta_informe(Number(keys[i])).subscribe({
-              next: (data: any) => {
-                respuesta = { ...respuesta, ...data }
-              },
-              error: (error: any) => {
-                this._snackBar.open("Error al buscar configuracion de practica", "Cerrar", {
-                  duration: 3000,
-                  panelClass: ['red-snackbar']
-                });
-                console.log("Error al buscar configuracion de practica", error);
-              },
-              complete: () => {
-                preguntas_informe.push(respuesta.body)
+            for (let i = 0; i < keys.length; i++) {
+              this.service_informe.get_pregunta_informe(Number(keys[i])).subscribe({
+                next: (data: any) => {
+                  respuesta = { ...respuesta, ...data }
+                },
+                error: (error: any) => {
+                  this._snackBar.open("Error al buscar configuracion de practica", "Cerrar", {
+                    duration: 3000,
+                    panelClass: ['red-snackbar']
+                  });
+                  console.log("Error al buscar configuracion de practica", error);
+                },
+                complete: () => {
+                  preguntas_informe.push(respuesta.body)
 
-                if (i == keys.length - 1) {
+                  if (i == keys.length - 1) {
 
-                  console.log(preguntas_informe)
-                  //console.log(preguntas_informe.length)
+                    console.log(preguntas_informe)
+                    //console.log(preguntas_informe.length)
 
-                  //orednar preguntas informe
-                  let preguntas_informe_ordenadas: any = []
+                    //orednar preguntas informe
+                    let preguntas_informe_ordenadas: any = []
 
-                  for (let id of keys) {
-                    for (let pregunta of preguntas_informe) {
-                      if (pregunta.id == id) {
-                        preguntas_informe_ordenadas.push(pregunta.enunciado)
+                    for (let id of keys) {
+                      for (let pregunta of preguntas_informe) {
+                        if (pregunta.id == id) {
+                          preguntas_informe_ordenadas.push(pregunta.enunciado)
+                        }
                       }
                     }
+
+                    console.log("preguntas informe ordenadas")
+                    console.log(preguntas_informe_ordenadas)
+
+                    let preguntas_respuestas_informes_aux = []
+
+                    for (let i = 0; i < preguntas_informe_ordenadas.length; i++) {
+                      preguntas_respuestas_informes_aux.push(preguntas_informe_ordenadas[i])
+                      preguntas_respuestas_informes_aux.push(lista_informes[i])
+                    }
+
+                    console.log("preguntas_respuestas_informes")
+                    console.log(preguntas_respuestas_informes_aux)
+
+                    this.preguntas_respuestas_informe = preguntas_respuestas_informes_aux
+
                   }
-
-                  console.log("preguntas informe ordenadas")
-                  console.log(preguntas_informe_ordenadas)
-
-                  let preguntas_respuestas_informes_aux = []
-
-                  for (let i = 0; i < preguntas_informe_ordenadas.length; i++) {
-                    preguntas_respuestas_informes_aux.push(preguntas_informe_ordenadas[i])
-                    preguntas_respuestas_informes_aux.push(lista_informes[i])
-                  }
-
-                  console.log("preguntas_respuestas_informes")
-                  console.log(preguntas_respuestas_informes_aux)
-
-                  this.preguntas_respuestas_informe = preguntas_respuestas_informes_aux
-
                 }
-              }
-            });
-          }
-
+              });
+            }
           //console.log(preguntas_informe)
-
-
-
+          }
 
         }
       }); // fin request para obtener la practica  

--- a/src/app/vistas/detalle-practica/detalle-practica.component.ts
+++ b/src/app/vistas/detalle-practica/detalle-practica.component.ts
@@ -112,7 +112,7 @@ export class DetallePracticaComponent implements OnInit {
         },
         complete: () => {
           this.practica = respuesta.body;
-          //console.log(this.practica);
+          console.log(this.practica);
           this.check_resumen();
 
           if(this.practica.ev_encargado==null){
@@ -214,69 +214,86 @@ export class DetallePracticaComponent implements OnInit {
             }
           }
 
-          if(this.practica.informes.length > 0){
-            //console.log(this.practica.informes[0].key)
+          
+          if(this.practica.informes.length > 0){           
 
-            //respuestas preguntas
-            let lista_informes = Object.values(this.practica.informes[0].key)
-            //console.log(lista_informes)
+            // buscar si hay algun informe que haya sido respondido (su key es un objeto no vacío), obtener su indice dentro del arreglo
+            let indice_informe_respondido = -1;
+            for (let i = 0; i < this.practica.informes.length; i++) {
+              if(this.practica.informes[i].key == null) continue;
+              if (Object.keys(this.practica.informes[i].key).length > 0) {
+                indice_informe_respondido = i;
+                break;
+              }
+            }
 
-            //id preguntas
-            let keys = Object.keys(this.practica.informes[0].key)
-            //console.log(keys)
+            if (indice_informe_respondido != -1) {
+              let key_informe_respondido = this.practica.informes[indice_informe_respondido].key;
 
-            let preguntas_informe: any = []
+              //console.log(key_informe_respondido)
 
-            for (let i = 0; i < keys.length; i++) {
-              this.service_informe.get_pregunta_informe(Number(keys[i])).subscribe({
-                next: (data: any) => {
-                  respuesta = { ...respuesta, ...data }
-                },
-                error: (error: any) => {
-                  this._snackBar.open("Error al buscar configuracion de practica", "Cerrar", {
-                    duration: 3000,
-                    panelClass: ['red-snackbar']
-                  });
-                  console.log("Error al buscar configuracion de practica", error);
-                },
-                complete: () => {
-                  preguntas_informe.push(respuesta.body)
+              //obtener las respuestas de las preguntas del informe
+              let lista_informes = Object.values(key_informe_respondido)
+              //console.log(lista_informes)
 
-                  if (i == keys.length - 1) {
+              //obtener los ids de las preguntas del informe
+              let keys = Object.keys(key_informe_respondido)
+              //console.log(keys)
 
-                    //console.log(preguntas_informe)
-                    //console.log(preguntas_informe.length)
+              let preguntas_informe: any = []
 
-                    //orednar preguntas informe
-                    let preguntas_informe_ordenadas: any = []
+              for (let i = 0; i < keys.length; i++) {
+                this.service_informe.get_pregunta_informe(Number(keys[i])).subscribe({
+                  next: (data: any) => {
+                    respuesta = { ...respuesta, ...data }
+                  },
+                  error: (error: any) => {
+                    this._snackBar.open("Error al buscar configuracion de practica", "Cerrar", {
+                      duration: 3000,
+                      panelClass: ['red-snackbar']
+                    });
+                    console.log("Error al buscar configuracion de practica", error);
+                  },
+                  complete: () => {
+                    preguntas_informe.push(respuesta.body)
 
-                    for (let id of keys) {
-                      for (let pregunta of preguntas_informe) {
-                        if (pregunta.id == id) {
-                          preguntas_informe_ordenadas.push(pregunta.enunciado)
+                    if (i == keys.length - 1) {
+
+                      //console.log(preguntas_informe)
+                      //console.log(preguntas_informe.length)
+
+                      //orednar preguntas informe
+                      let preguntas_informe_ordenadas: any = []
+
+                      for (let id of keys) {
+                        for (let pregunta of preguntas_informe) {
+                          if (pregunta.id == id) {
+                            preguntas_informe_ordenadas.push(pregunta.enunciado)
+                          }
                         }
                       }
+
+                      //console.log("preguntas informe ordenadas")
+                      //console.log(preguntas_informe_ordenadas)
+
+                      let preguntas_respuestas_informes_aux = []
+
+                      for (let i = 0; i < preguntas_informe_ordenadas.length; i++) {
+                        preguntas_respuestas_informes_aux.push(preguntas_informe_ordenadas[i])
+                        preguntas_respuestas_informes_aux.push(lista_informes[i])
+                      }
+
+                      //console.log("preguntas_respuestas_informes")
+                      //console.log(preguntas_respuestas_informes_aux)
+
+                      this.preguntas_respuestas_informe = preguntas_respuestas_informes_aux
+
                     }
-
-                    //console.log("preguntas informe ordenadas")
-                    //console.log(preguntas_informe_ordenadas)
-
-                    let preguntas_respuestas_informes_aux = []
-
-                    for (let i = 0; i < preguntas_informe_ordenadas.length; i++) {
-                      preguntas_respuestas_informes_aux.push(preguntas_informe_ordenadas[i])
-                      preguntas_respuestas_informes_aux.push(lista_informes[i])
-                    }
-
-                    //console.log("preguntas_respuestas_informes")
-                    //console.log(preguntas_respuestas_informes_aux)
-
-                    this.preguntas_respuestas_informe = preguntas_respuestas_informes_aux
-
                   }
-                }
-              });
-            }
+                });
+              }
+              
+            }            
           //console.log(preguntas_informe)
           }
 
@@ -647,6 +664,7 @@ export class DetallePracticaComponent implements OnInit {
   }
 
   isDataEmpty(data: any): boolean {
+    if (data == null || data == undefined) return true;
     return Object.keys(data).length === 0 && data.constructor === Object;
   }
 

--- a/src/app/vistas/informe/informe.component.html
+++ b/src/app/vistas/informe/informe.component.html
@@ -10,9 +10,21 @@
 
             <!-- Begin Page Content -->
             <div class="container">
-                <h1 class="h3 mb-1 text-gray-800">
-                    Informe: {{fecha_informe}}
-                </h1>
+                <div class="row">
+                    <div class="col-xl-10">
+                        <div class="h3 mb-1 mt-4 text-gray-800">
+                            Informe: {{fecha_informe}}
+                        </div>
+                    </div>
+                    <div class="col-xl-1">
+                    </div>
+                    <div class="col-xl-1">
+                        <!--boton para volver a pagina anterior-->
+                        <a class="btn btn-primary btn-md mt-4" href="javascript:history.back()">
+                            <span class="text">Volver</span>
+                        </a>
+                    </div>
+                </div>
                 <div class="mt-3 card mb-4" *ngFor="let item of pares_pregunta_respuesta">
                     <div class="card-header">
                         {{item[0]}}

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -27,23 +27,22 @@
                                 cellspacing="0">
                                 <thead id="headerTabla">
                                     <tr>
-                                        <th (click)="sort(1)">Nombre Estudiante</th>
-                                        <th (click)="sort(2)">Rut</th>
-                                        <th (click)="sort(3)">Tipo Práctica</th>
-                                        <th (click)="sort(4)">Estado</th>
-                                        <th (click)="sort(5)">Nota Supervisor
+                                        <th (click)="sort(1)" [class.asc]="sortedColumn === 1 && sortOrder === -1" [class.desc]="sortedColumn === 1 && sortOrder === 1">Nombre Estudiante</th>
+                                        <th (click)="sort(2)" [class.asc]="sortedColumn === 2 && sortOrder === -1" [class.desc]="sortedColumn === 2 && sortOrder === 1">Rut</th>
+                                        <th (click)="sort(3)" [class.asc]="sortedColumn === 3 && sortOrder === -1" [class.desc]="sortedColumn === 3 && sortOrder === 1">Tipo Práctica</th>
+                                        <th (click)="sort(4)" [class.asc]="sortedColumn === 4 && sortOrder === -1" [class.desc]="sortedColumn === 4 && sortOrder === 1">Estado</th>
+                                        <th class="exclude-hover">Nota Supervisor
                                             <a class ="pointer" title="{{texto_promedio_evaluacion}}"
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
                                                     class="fas fa-info-circle"></i></a>
                                         </th>
-                                        <th (click)="sort(6)">Nota Encargado
+                                        <th class="exclude-hover">Nota Encargado
                                             <a class="pointer" title="{{texto_evaluacion_encargado}}"
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
                                                     class="fas fa-info-circle"></i></a>
                                         </th>
-                                        <th style="vertical-align: bottom">Aprobación</th>                                        
-                                    </tr>
-                            
+                                        <th class="exclude-hover" style="vertical-align: bottom">Aprobación</th>                                        
+                                    </tr>                            
                                 </thead>
                                 <tbody>
                                     <tr id="cuerpoTabla" class="pointer" *ngFor="let practica of practicas; let indice=index">
@@ -63,9 +62,9 @@
                                                 <div *ngIf="isNumber(ev_values[indice])"><!-- format the number so that it has 2 decimal places-->
                                                     {{ ev_values[indice] | number: '1.2' }}
                                                 </div>
-                                                <button *ngIf="!isNumber(ev_values[indice]); else yaEvaluado" class="btn btn-primary btn-user" (click)="editar(indice)">Evaluar</button>
+                                                <button *ngIf="!isNumber(ev_values[indice]); else yaEvaluado" class="btn btn-sm btn-primary btn-user" (click)="editar(indice)">Evaluar</button>
                                                 <ng-template #yaEvaluado>
-                                                    <button class="btn btn-secondary btn-user"  (click)="editar(indice)">Cambiar</button>
+                                                    <button class="btn btn-sm btn-secondary btn-user"  (click)="editar(indice)">Cambiar</button>
                                                 </ng-template>
                                             </div>
                                             <ng-template #editable>
@@ -77,7 +76,7 @@
                                                     <option value=4>4</option>
                                                     <option value=5>5</option>
                                                 </select>
-                                                <button class="btn btn-primary btn-user btn-block" (click)="evaluacion_encargado(practica.id, indice)">Confirmar</button>
+                                                <button class="btn btn-sm btn-primary btn-user btn-block" (click)="evaluacion_encargado(practica.id, indice)">Confirmar</button>
                                             </ng-template>
                                         </td>
                                         <td [ngSwitch]="practica.estado">

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -30,7 +30,7 @@
                                         <th (click)="sort(1)" [class.asc]="sortedColumn === 1 && sortOrder === -1" [class.desc]="sortedColumn === 1 && sortOrder === 1">Nombre Estudiante</th>
                                         <th (click)="sort(2)" [class.asc]="sortedColumn === 2 && sortOrder === -1" [class.desc]="sortedColumn === 2 && sortOrder === 1">Rut</th>
                                         <th (click)="sort(3)" [class.asc]="sortedColumn === 3 && sortOrder === -1" [class.desc]="sortedColumn === 3 && sortOrder === 1">Tipo Práctica</th>
-                                        <th (click)="sort(4)" [class.asc]="sortedColumn === 4 && sortOrder === -1" [class.desc]="sortedColumn === 4 && sortOrder === 1">Estado</th>
+                                        <th (click)="sort(4)" [class.asc]="sortedColumn === 4 && sortOrder === -1" [class.desc]="sortedColumn === 4 && sortOrder === -1">Estado</th>
                                         <th class="exclude-hover">Nota Supervisor
                                             <a class ="pointer" title="{{texto_promedio_evaluacion}}"
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
@@ -45,26 +45,26 @@
                                     </tr>                            
                                 </thead>
                                 <tbody>
-                                    <tr id="cuerpoTabla" class="pointer" *ngFor="let practica of practicas; let indice=index">
+                                    <tr id="cuerpoTabla" class="pointer" *ngFor="let practica of practicas">
                                         <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">{{practica?.estudiante?.usuario?.nombre}}</td>
                                         <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">{{practica?.estudiante?.rut}}</td>
                                         <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">
                                             {{practica?.modalidad?.config_practica?.nombre}}</td>
                                         <td class="font-weight-bold" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}" [ngClass]="getEstadoClass(practica.estado)">
                                             {{ practica?.estado === 'Evaluada' ? 'Evaluada por supervisor' : practica?.estado === 'Finalizada' ? 'Esperando evaluación de supervisor' : practica?.estado }}</td>
-                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"><!--Check if notas_promedio[indice] is a number-->
-                                            <div *ngIf="isNumber(notas_promedio[indice])">
-                                                {{notas_promedio[indice] | number: '1.2-2' }}
+                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"><!--Check if notas_promedio[practica.id] is a number-->
+                                            <div *ngIf="isNumber(notas_promedio[practica.id])">
+                                                {{notas_promedio[practica.id] | number: '1.2-2' }}
                                             </div>
                                         </td>
                                         <td>
-                                            <div *ngIf="editables[indice]=='0'; else editable">
-                                                <div *ngIf="isNumber(ev_values[indice])"><!-- format the number so that it has 2 decimal places-->
-                                                    {{ ev_values[indice] | number: '1.2' }}
+                                            <div *ngIf="editables[practica.id]=='0'; else editable">
+                                                <div *ngIf="isNumber(ev_values[practica.id])"><!-- format the number so that it has 2 decimal places-->
+                                                    {{ ev_values[practica.id] | number: '1.2' }}
                                                 </div>
-                                                <button *ngIf="!isNumber(ev_values[indice]); else yaEvaluado" class="btn btn-sm btn-primary btn-user" (click)="editar(indice)">Evaluar</button>
+                                                <button *ngIf="!isNumber(ev_values[practica.id]); else yaEvaluado" class="btn btn-sm btn-primary btn-user" (click)="editar(practica.id)">Evaluar</button>
                                                 <ng-template #yaEvaluado>
-                                                    <button class="btn btn-sm btn-secondary btn-user"  (click)="editar(indice)">Cambiar</button>
+                                                    <button class="btn btn-sm btn-secondary btn-user"  (click)="editar(practica.id)">Cambiar</button>
                                                 </ng-template>
                                             </div>
                                             <ng-template #editable>
@@ -76,7 +76,7 @@
                                                     <option value=4>4</option>
                                                     <option value=5>5</option>
                                                 </select>
-                                                <button class="btn btn-sm btn-primary btn-user btn-block" (click)="evaluacion_encargado(practica.id, indice)">Confirmar</button>
+                                                <button class="btn btn-sm btn-primary btn-user btn-block" (click)="evaluacion_encargado(practica.id)">Confirmar</button>
                                             </ng-template>
                                         </td>
                                         <td [ngSwitch]="practica.estado">

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -25,7 +25,7 @@
                         <div class="table-responsive sortable" >
                             <table class="table table-striped table-bordered table-hover sortable" id="dataTable" width="100%"
                                 cellspacing="0">
-                                <thead>
+                                <thead class="headerTabla">
                                     <tr>
                                         <th style="vertical-align: bottom;" (click)="sort(1)">Nombre Estudiante</th>
                                         <th style="vertical-align: bottom;" (click)="sort(2)">Rut</th>
@@ -41,8 +41,9 @@
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
                                                     class="fas fa-info-circle"></i></a>
                                         </th>
-                                        <th style="vertical-align: bottom;">Aprobación</th>
+                                        <th style="vertical-align: bottom">Aprobación</th>                                        
                                     </tr>
+                            
                                 </thead>
                                 <tbody>
                                     <tr class="pointer" *ngFor="let practica of practicas; let indice=index">

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -22,8 +22,7 @@
                 <!-- DataTales Example -->
                 <div class="card shadow mb-4">
                     <div class="card-body">
-
-                        <div class="table-responsive sortable">
+                        <div class="table-responsive sortable" >
                             <table class="table table-striped table-bordered table-hover sortable" id="dataTable" width="100%"
                                 cellspacing="0">
                                 <thead>
@@ -111,6 +110,7 @@
                                         </td>
                                     </tr>
                                 </tbody>
+                                
                             </table>
                         </div>
                     </div>

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -52,7 +52,7 @@
                                         <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">
                                             {{practica?.modalidad?.config_practica?.nombre}}</td>
                                         <td class="font-weight-bold" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}" [ngClass]="getEstadoClass(practica.estado)">
-                                            {{ practica?.estado === 'Evaluada' ? 'Evaluada por supervisor' : practica?.estado }}</td>
+                                            {{ practica?.estado === 'Evaluada' ? 'Evaluada por supervisor' : practica?.estado === 'Finalizada' ? 'Esperando evaluación de supervisor' : practica?.estado }}</td>
                                         <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"><!--Check if notas_promedio[indice] is a number-->
                                             <div *ngIf="isNumber(notas_promedio[indice])">
                                                 {{notas_promedio[indice] | number: '1.2-2' }}
@@ -102,7 +102,7 @@
                                                 [estado_practica]="practica.estado"
                                             >
                                             </app-revision>
-                                            <div *ngSwitchDefault>Esperando evaluación del supervisor</div>
+                                            <div *ngSwitchDefault>No disponible</div>
                                         </td>
                                     </tr>
                                 </tbody>

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -22,8 +22,8 @@
                 <!-- DataTales Example -->
                 <div class="card shadow mb-4">
                     <div class="card-body">
-                        <div class="table-responsive sortable" >
-                            <table class="table table-striped" id="dataTable" width="100%"
+                        <div class="table-responsive table-hover" >
+                            <table class="table table-striped table-hover" id="dataTable" width="100%"
                                 cellspacing="0">
                                 <thead id="headerTabla">
                                     <tr>

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.html
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.html
@@ -23,20 +23,20 @@
                 <div class="card shadow mb-4">
                     <div class="card-body">
                         <div class="table-responsive sortable" >
-                            <table class="table table-striped table-bordered table-hover sortable" id="dataTable" width="100%"
+                            <table class="table table-striped" id="dataTable" width="100%"
                                 cellspacing="0">
-                                <thead class="headerTabla">
+                                <thead id="headerTabla">
                                     <tr>
-                                        <th style="vertical-align: bottom;" (click)="sort(1)">Nombre Estudiante</th>
-                                        <th style="vertical-align: bottom;" (click)="sort(2)">Rut</th>
-                                        <th style="vertical-align: bottom;" (click)="sort(3)">Tipo Práctica</th>
-                                        <th style="vertical-align: bottom;" (click)="sort(4)">Estado</th>
-                                        <th style="vertical-align: bottom;" (click)="sort(5)">Nota Supervisor
+                                        <th (click)="sort(1)">Nombre Estudiante</th>
+                                        <th (click)="sort(2)">Rut</th>
+                                        <th (click)="sort(3)">Tipo Práctica</th>
+                                        <th (click)="sort(4)">Estado</th>
+                                        <th (click)="sort(5)">Nota Supervisor
                                             <a class ="pointer" title="{{texto_promedio_evaluacion}}"
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
                                                     class="fas fa-info-circle"></i></a>
                                         </th>
-                                        <th style="vertical-align:bottom;" (click)="sort(6)">Nota Encargado
+                                        <th (click)="sort(6)">Nota Encargado
                                             <a class="pointer" title="{{texto_evaluacion_encargado}}"
                                                 data-toggle="tooltip" data-placement="bottom" (click)="redirecting()"><i
                                                     class="fas fa-info-circle"></i></a>
@@ -46,24 +46,19 @@
                             
                                 </thead>
                                 <tbody>
-                                    <tr class="pointer" *ngFor="let practica of practicas; let indice=index">
-                                        <td class="table-item" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"
-                                            style="vertical-align: middle;">{{practica?.estudiante?.usuario?.nombre}}</td>
-                                        <td class="table-item" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"
-                                            style="vertical-align: middle;">{{practica?.estudiante?.rut}}</td>
-                                        <td class="table-item" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"
-                                            style="vertical-align: middle;">
+                                    <tr id="cuerpoTabla" class="pointer" *ngFor="let practica of practicas; let indice=index">
+                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">{{practica?.estudiante?.usuario?.nombre}}</td>
+                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">{{practica?.estudiante?.rut}}</td>
+                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}">
                                             {{practica?.modalidad?.config_practica?.nombre}}</td>
-                                        <td class="table-item font-weight-bold" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"
-                                            style="vertical-align: middle;" [ngClass]="getEstadoClass(practica.estado)">
+                                        <td class="font-weight-bold" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}" [ngClass]="getEstadoClass(practica.estado)">
                                             {{ practica?.estado === 'Evaluada' ? 'Evaluada por supervisor' : practica?.estado }}</td>
-                                        <td class="table-item" routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"
-                                            style="vertical-align: middle;"><!--Check if notas_promedio[indice] is a number-->
+                                        <td routerLink="/{{rutas.ruta_practicas}}/{{practica.id}}"><!--Check if notas_promedio[indice] is a number-->
                                             <div *ngIf="isNumber(notas_promedio[indice])">
                                                 {{notas_promedio[indice] | number: '1.2-2' }}
                                             </div>
                                         </td>
-                                        <td class="table-item" style="vertical-align: middle;">
+                                        <td>
                                             <div *ngIf="editables[indice]=='0'; else editable">
                                                 <div *ngIf="isNumber(ev_values[indice])"><!-- format the number so that it has 2 decimal places-->
                                                     {{ ev_values[indice] | number: '1.2' }}
@@ -85,7 +80,7 @@
                                                 <button class="btn btn-primary btn-user btn-block" (click)="evaluacion_encargado(practica.id, indice)">Confirmar</button>
                                             </ng-template>
                                         </td>
-                                        <td [ngSwitch]="practica.estado" style="vertical-align: middle;">
+                                        <td [ngSwitch]="practica.estado">
                                             <app-revision *ngSwitchCase="'Evaluada'"
                                                 [id_estudiante]="practica.id_estudiante"
                                                 [id_modalidad]="practica.modalidad.id"

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
@@ -1,19 +1,24 @@
+thead {
+    border: #e4e4e4 solid 1px;
+}
+
 thead th {
     text-align: center;
     color: #727272;
     vertical-align: middle;
 }
 
-tbody{
-    max-height: calc(100vh - 350px);
-    display: block;
-    overflow: auto;
-}
-
 thead :hover{
     background-color: #e7e7e7;
     cursor: pointer;
 }
+
+tbody{
+    max-height: calc(100vh - 350px);
+    display: block;
+    overflow-y: auto;
+}
+
 
 thead, tbody tr {
     display: table;
@@ -22,14 +27,9 @@ thead, tbody tr {
 }
 
 tbody tr td {
-    vertical-align: middle;
+    vertical-align: middle !important;
     text-align: center;
     color: #686868;
-}
-
-.table-item {
-    vertical-align: middle;
-    text-align: center;
 }
 
 .custom-tooltip {
@@ -40,6 +40,3 @@ tbody tr td {
     cursor: pointer;
 }
 
-.headerTabla {
-    width: calc(100% - 16px);
-}

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
@@ -1,25 +1,39 @@
-thead th{
+thead th {
     text-align: center;
     color: #727272;
     vertical-align: middle;
-    background-color: #e7e7e7; 
+    background-color: #e7e7e7;
     border-color: #d6d6d6;
+    position: sticky;
+    top: 0;
 }
 
-tbody tr td{
+tbody{
+    display: block;
+    overflow: auto;
+    max-height: 60vh;
+}
+
+thead, tbody tr {
+    display: table;
+    width: 100%;
+    table-layout: fixed;/* even columns width , fix width of table too*/
+}
+
+tbody tr td {
     vertical-align: middle;
     text-align: center;
     color: #686868;
 }
 
-.table-item{
+.table-item {
     vertical-align: middle;
     text-align: center;
 }
 
 .custom-tooltip {
-    font-size:25px;
- }
+    font-size: 25px;
+}
 
 .pointer {
     cursor: pointer;

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
@@ -2,16 +2,17 @@ thead th {
     text-align: center;
     color: #727272;
     vertical-align: middle;
-    background-color: #e7e7e7;
-    border-color: #d6d6d6;
-    position: sticky;
-    top: 0;
 }
 
 tbody{
+    max-height: calc(100vh - 350px);
     display: block;
     overflow: auto;
-    max-height: 60vh;
+}
+
+thead :hover{
+    background-color: #e7e7e7;
+    cursor: pointer;
 }
 
 thead, tbody tr {
@@ -37,4 +38,8 @@ tbody tr td {
 
 .pointer {
     cursor: pointer;
+}
+
+.headerTabla {
+    width: calc(100% - 16px);
 }

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.scss
@@ -8,7 +8,7 @@ thead th {
     vertical-align: middle;
 }
 
-thead :hover{
+thead th:not(.exclude-hover):hover {
     background-color: #e7e7e7;
     cursor: pointer;
 }
@@ -40,3 +40,12 @@ tbody tr td {
     cursor: pointer;
 }
 
+/* Ascending arrow style */
+.asc:after {
+    content: ' ▲'; /* Up arrow */
+  }
+  
+  /* Descending arrow style */
+  .desc:after {
+    content: ' ▼'; /* Down arrow */
+  }

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ViewChild, ViewEncapsulation, HostListener } from '@angular/core';
 import { DataTableDirective } from 'angular-datatables';
 import { GetDetallesAlumnoService } from '../../servicios/encargado/resumen_practicas.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -107,6 +107,8 @@ export class TablaComponent {
           }
         }
 
+        
+
         this.practicas = temppracticas.map((alumno: any) => {
 
           alumno.consistencia_nota = alumno.consistencia_nota ? `${Math.round(100 * alumno.consistencia_nota)}%` : "—";
@@ -180,16 +182,20 @@ export class TablaComponent {
                   this.notas_promedio.push(item2[1])
                 }
               }
-              //console.log(this.notas_promedio)
+              //console.log(this.notas_promedio) 
+              const element = document.getElementById('cuerpoTabla');
+              const targetElement = document.getElementById('headerTabla');
+              if (element) {
+                const elementWidth = element.offsetWidth;
+                targetElement!.style.width = elementWidth + 'px';
+              }  
             }
           });
-        }     
-        this.rerender();
+        }
       }
     });
   }
-  rerender(): void {
-  }
+
 
   ngAfterViewInit(): void {
     this.dtTrigger.next(0);
@@ -306,6 +312,19 @@ export class TablaComponent {
 
   }
 
+  @HostListener('window:resize', ['$event'])
+  onResize(event: Event): void {
+    // Handle the window resize event here
+    console.log('Window has been resized', window.innerWidth, window.innerHeight);
+    // You can put your custom logic here
+    const element = document.getElementById('cuerpoTabla');
+              const targetElement = document.getElementById('headerTabla');
+              if (element) {
+                const elementWidth = element.offsetWidth;
+                targetElement!.style.width = elementWidth + 'px';
+              }  
+  }
+
   editar(index:number){
     this.editables[index] = "1"
   }
@@ -352,4 +371,6 @@ export class TablaComponent {
         return ''; // Clase por defecto o ninguna clase si no coincide
     }
   }
+
+  
 }

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
@@ -210,7 +210,13 @@ export class TablaComponent {
     this.dtTrigger.unsubscribe();
   }
 
+  sortedColumn: number | null = null;
+  sortOrder: number | null = null;
+
   sort(n:number) {
+    this.sortedColumn = n;
+    this.sortOrder = this.booleanValue ? 1 : -1;
+    console.log(this.booleanValue, this.sortOrder)
     if (this.booleanValue == false){
       switch(n){
         case 1:
@@ -235,15 +241,6 @@ export class TablaComponent {
           this.practicas.sort((a:any, b:any) => a.estado > b.estado ? 1 :
                                                 a.estado < b.estado ? -1 :
                                                 0 
-          )
-          break;
-        case 5:
-          this.notas_promedio.sort((a:any, b:any) => a > b ? 1 : a < b ? -1 : 0);
-          break;
-        case 6:
-          this.practicas.sort((a:any, b:any) => a.ev_encargado > b.ev_encargado ? 1 :
-                                                a.ev_encargado < b.ev_encargado ? -1:
-                                                0
           )
           break;
       }

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
@@ -35,8 +35,8 @@ export class TablaComponent {
 
   booleanValue: boolean = true;
   
-  editables:any = [];
-  ev_values:any = [];
+  editables:any = {};
+  ev_values:any = {};
 
   ev_value:number = -1;
 
@@ -93,29 +93,31 @@ export class TablaComponent {
         });
       },
       complete: () => {
+        
+
         let temppracticas:any = [];
 
-        for (let alumno of respuesta.body){
+        for (let practicaux of respuesta.body){
           //console.log(alumno)
-          if (alumno?.modalidad?.config_practica?.id_carrera == this.carrera_encargado && alumno?.modalidad?.config_practica?.id_carrera != null){
-            temppracticas.push(alumno);
-            if(alumno.ev_encargado == null || alumno.ev_encargado == -1){
-              this.ev_values.push("-")
+          if (practicaux?.modalidad?.config_practica?.id_carrera == this.carrera_encargado && practicaux?.modalidad?.config_practica?.id_carrera != null){
+            temppracticas.push(practicaux);
+            if(practicaux.ev_encargado == null || practicaux.ev_encargado == -1){
+              this.ev_values[practicaux.id] = "-"
               }else{
-              this.ev_values.push(alumno.ev_encargado)
+              this.ev_values[practicaux.id]= practicaux.ev_encargado
               }
           }
         }
 
         
 
-        this.practicas = temppracticas.map((alumno: any) => {
+        this.practicas = temppracticas.map((practicaux: any) => {
 
-          alumno.consistencia_nota = alumno.consistencia_nota ? `${Math.round(100 * alumno.consistencia_nota)}%` : "—";
-          alumno.consistencia_informe = alumno.consistencia_informe ? `${Math.round(100 * alumno.consistencia_informe)}%` : "—";
-          alumno.nota_evaluacion = alumno.nota_evaluacion ? alumno.nota_evaluacion : "—";
-          alumno.interpretacion_nota = alumno.interpretacion_nota ? alumno.interpretacion_nota : "—";
-          alumno.interpretacion_informe = alumno.interpretacion_informe ? alumno.interpretacion_informe : "—";
+          practicaux.consistencia_nota = practicaux.consistencia_nota ? `${Math.round(100 * practicaux.consistencia_nota)}%` : "—";
+          practicaux.consistencia_informe = practicaux.consistencia_informe ? `${Math.round(100 * practicaux.consistencia_informe)}%` : "—";
+          practicaux.nota_eval = practicaux.nota_eval ? practicaux.nota_eval : "—";
+          practicaux.interpretacion_nota = practicaux.interpretacion_nota ? practicaux.interpretacion_nota : "—";
+          practicaux.interpretacion_informe = practicaux.interpretacion_informe ? practicaux.interpretacion_informe : "—";
           
           /*alumno ={... alumno, carrera: this.carreras[Math.floor(Math.random() * this.carreras.length)]}
           console.log(alumno);
@@ -124,12 +126,13 @@ export class TablaComponent {
             this.practicas.splice(index, 1);
           }
           */
-          return alumno;
+          return practicaux;
         });
-        for (var item of this.practicas){
-          this.editables.push("0");
-          let iditem = item.id
-          this.practi_service.obtener_practica(item.id).subscribe({
+        console.log(this.practicas)
+        for (var practicaux of this.practicas){
+          this.editables[practicaux.id] = "0"
+          let id_practicaux = practicaux.id
+          this.practi_service.obtener_practica(id_practicaux).subscribe({
             next: (data: any) => {
               respuesta = { ...respuesta, ...data }
             },
@@ -144,7 +147,7 @@ export class TablaComponent {
               //console.log(evaluaciones)
               
               if(evaluaciones.length == 0){
-                this.temp_notas.push([iditem, 0])
+                this.temp_notas.push([id_practicaux, 0])
               }
               else{
                 let find = -1
@@ -162,24 +165,24 @@ export class TablaComponent {
                         prom += 1;
                       } 
                       nota_promedio = nota_promedio/prom
-                      this.temp_notas.push([iditem, nota_promedio])  
+                      this.temp_notas.push([id_practicaux, nota_promedio])  
                       break
                     }
                   }
                 }
                 if (find == -1){
-                  this.temp_notas.push([iditem, 0])
+                  this.temp_notas.push([id_practicaux, 0])
                 } 
               }
               this.temp_notas.sort(function(a:any, b:any){
                 return a[0] - b[0];
               })
               this.notas_promedio = [];
-              for (let item2 of this.temp_notas){
-                if (item2[1] == 0){
+              for (let nota_temp of this.temp_notas){
+                if (nota_temp[1] == 0){
                   this.notas_promedio.push("-")
                 } else{
-                  this.notas_promedio.push(item2[1])
+                  this.notas_promedio.push(nota_temp[1])
                 }
               }
               //console.log(this.notas_promedio) 
@@ -216,7 +219,7 @@ export class TablaComponent {
   sort(n:number) {
     this.sortedColumn = n;
     this.sortOrder = this.booleanValue ? 1 : -1;
-    console.log(this.booleanValue, this.sortOrder)
+    //console.log(this.booleanValue, this.sortOrder)
     if (this.booleanValue == false){
       switch(n){
         case 1:
@@ -270,39 +273,6 @@ export class TablaComponent {
                                                 a.estado > b.estado ? -1 :
                                                 0 
           )
-          break;
-        case 5:
-          this.practicas.sort((a:any, b:any) => a.indice_repeticion < b.indice_repeticion ? 1 :
-                                                a.indice_repeticion > b.indice_repeticion ? -1 :
-                                                0 
-          )
-          break;
-        case 6:
-          this.practicas.sort((a:any, b:any) => a.consistencia_informe < b.consistencia_informe ? 1 :
-                                                a.consistencia_informe > b.consistencia_informe ? -1 :
-                                                0 
-          )
-          break;
-        case 7:
-          this.practicas.sort((a:any, b:any) => a.consistencia_nota < b.consistencia_nota ? 1 :
-                                                a.consistencia_nota > b.consistencia_nota ? -1 :
-                                                0 
-          )
-          break;
-        case 8:
-          this.practicas.sort((a:any, b:any) => a.interpretacion_nota < b.interpretacion_nota ? 1 :
-                                                a.interpretacion_nota > b.interpretacion_nota ? -1 :
-                                                0 
-          )
-          break;
-        case 9: 
-          this.practicas.sort((a:any, b:any) => a.interpretacion_informe < b.interpretacion_informe ? 1 :
-                                                a.interpretacion_informe > b.interpretacion_informe ? -1 :
-                                                0 
-          )
-          break;
-        case 10:
-          this.notas_promedio.sort((a:any, b:any) => a < b ? 1 : a > b ? -1 : 0)
       }
       this.booleanValue = !this.booleanValue
     }
@@ -322,17 +292,17 @@ export class TablaComponent {
     }  
   }
 
-  editar(index:number){
-    this.editables[index] = "1"
+  editar(id_practica:number){
+    this.editables[id_practica] = "1"
   }
 
   checkout(arg: any) {
     this.ev_value = Number(arg.target.value)
   }
 
-  evaluacion_encargado(id_practica:number, index:number){
+  evaluacion_encargado(id_practica:number){
     if(this.ev_value == -1){
-      this.editables[index] = "0"
+      this.editables[id_practica] = "0"
       return;
     }
     let respuesta:any = [];
@@ -347,8 +317,8 @@ export class TablaComponent {
       complete:() => {
       }
     })
-    this.editables[index] = "0"
-    this.ev_values[index] = this.ev_value;
+    this.editables[id_practica] = "0"
+    this.ev_values[id_practica] = this.ev_value;
     this.ev_value = -1
   }
 

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
@@ -315,14 +315,14 @@ export class TablaComponent {
   @HostListener('window:resize', ['$event'])
   onResize(event: Event): void {
     // Handle the window resize event here
-    console.log('Window has been resized', window.innerWidth, window.innerHeight);
+    //console.log('Window has been resized', window.innerWidth, window.innerHeight);
     // You can put your custom logic here
     const element = document.getElementById('cuerpoTabla');
-              const targetElement = document.getElementById('headerTabla');
-              if (element) {
-                const elementWidth = element.offsetWidth;
-                targetElement!.style.width = elementWidth + 'px';
-              }  
+    const targetElement = document.getElementById('headerTabla');
+    if (element) {
+      const elementWidth = element.offsetWidth;
+      targetElement!.style.width = elementWidth + 'px';
+    }  
   }
 
   editar(index:number){

--- a/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
+++ b/src/app/vistas/resumen_practicas/resumen_practicas.component.ts
@@ -97,7 +97,7 @@ export class TablaComponent {
 
         for (let alumno of respuesta.body){
           //console.log(alumno)
-          if (alumno.modalidad.config_practica.id_carrera == this.carrera_encargado && alumno.modalidad.config_practica.id_carrera != null){
+          if (alumno?.modalidad?.config_practica?.id_carrera == this.carrera_encargado && alumno?.modalidad?.config_practica?.id_carrera != null){
             temppracticas.push(alumno);
             if(alumno.ev_encargado == null || alumno.ev_encargado == -1){
               this.ev_values.push("-")

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,13 +12,10 @@ body {
     align-self: flex-end;
 }
 
-.navbar{
-    height: 9vh;
-}
-
 .container-fluid{
-    overflow: auto;
-    height: 91vh;
+    height: calc(100vh - 60px);
     display: block;
     padding-top: 20px;
+    overflow: auto;
 }
+


### PR DESCRIPTION
En resumen de prácticas (vista del encargado):
-Verificar que se vea decente la tabla y no tenga cosas raras.
-Los botones de Aprobar y Reprobar deberían cambiar a un botón gris si la práctica ya está Aprobada o Reprobada
-Se debería ver el estado de la práctica en colores
-Se debería poder scrollear en la tabla sin perder el header, y sin que se salga de la página el cuadro que contiene la tabla.
-Se debería poder ordenar asc o desc según nombre, rut, tipo de práctica y estado

En vista de detalle de práctica:
-Si no hay informes, no debería salir error
-Si hay un informe no respondido (el campo "key" es null), no debería poder debería mostrar que no ha sido subido
-Las tablas de evaluación, informes, solicitudes, deberían mostrar que no hay datos, en vez de la tabla, cuando no hay datos.
-El resumen generado por IA ya no debería salirse de la tarjeta que lo contiene, cuando es más o menos largo.

En barra superior:
-El widget de chat ahora tiene scroll, se ve cuando hay muchos alumnos o encargados en la lista (ver con un encargado de informática)
-Se elimina el botón de "Más mensajes"


