### PR TITLE
Informe final de tipo archivo, en config practica

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@ng-bootstrap/ng-bootstrap": "^15.0.1",
         "@popperjs/core": "^2.11.6",
         "@schematics/angular": "^9.1.15",
+        "@syncfusion/ej2-base": "^23.1.41",
         "@types/pdfmake": "^0.2.2",
         "angular-datatables": "^15.0.1",
         "bootstrap": "^5.3.2",
@@ -4828,6 +4829,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@syncfusion/ej2-base": {
+      "version": "23.1.41",
+      "resolved": "https://registry.npmjs.org/@syncfusion/ej2-base/-/ej2-base-23.1.41.tgz",
+      "integrity": "sha512-ROtvuLIVkKl4eL+ubQjQQLleRMY98nYlxlBaFw4axtiDLoBbzOYtiFXmdP/KE+uNrMquZAwl+aduPX0loG3EAw==",
+      "dependencies": {
+        "@syncfusion/ej2-icons": "~23.1.36"
+      },
+      "bin": {
+        "syncfusion-license": "bin/syncfusion-license.js"
+      }
+    },
+    "node_modules/@syncfusion/ej2-icons": {
+      "version": "23.1.36",
+      "resolved": "https://registry.npmjs.org/@syncfusion/ej2-icons/-/ej2-icons-23.1.36.tgz",
+      "integrity": "sha512-Q7S50bOzXL9X46doNIGSGr61RCY/1RW9iz1U7yyARr2XBQhWnijk+t/FVBk1piR0nioRXbKQcPZOLiEo6zf1xw=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@ng-bootstrap/ng-bootstrap": "^15.0.1",
     "@popperjs/core": "^2.11.6",
     "@schematics/angular": "^9.1.15",
+    "@syncfusion/ej2-base": "^23.1.41",
     "@types/pdfmake": "^0.2.2",
     "angular-datatables": "^15.0.1",
     "bootstrap": "^5.3.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,6 +88,7 @@ import { VistaConfigsPracticaComponent } from './vistas/vista-configs-practica/v
 import { EdicionSimpleModalComponent } from './componentes/edicion-simple-modal/edicion-simple-modal.component';
 import { PlagiosComponent } from './vistas/plagios/plagios.component';
 import { ComentariosModalComponent } from './componentes/comentarios-modal/comentarios-modal.component';
+import { SubirPlantillaInformeFinalComponent } from './componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component';
 
 @NgModule({
   declarations: [
@@ -142,6 +143,7 @@ import { ComentariosModalComponent } from './componentes/comentarios-modal/comen
     EdicionSimpleModalComponent,
     PlagiosComponent,
     ComentariosModalComponent,
+    SubirPlantillaInformeFinalComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/componentes/subir-plantilla-informe-final/dialogPlantilla.html
+++ b/src/app/componentes/subir-plantilla-informe-final/dialogPlantilla.html
@@ -1,0 +1,22 @@
+<div class="row m-0 p-0" style="max-width: 100%">
+    <div class="col-xl-12 p-0" >
+        <div class="card">
+            <a class="card-header">
+                <h3 class="m-0 font-weight-bold text-primary" style="text-align: center;">Plantilla para Informe Final</h3>
+            </a>
+            <div class="card-body text-gray-800" style="text-align: center;">  
+
+                <form style="width: 100%;">
+                    <span class="file-name">{{selectedFile?.name}}</span>
+                    <button type="button" class="btn btn-primary btn-md" (click)="fileInput.click()">Elegir Archivo</button>
+                    <input hidden (change)="onFileSelected($event)" #fileInput type="file" required>                    
+                </form>
+                <div mat-dialog-actions class="d-flex justify-content-center">
+                        <div class="p-2"><button [mat-dialog-close]="[false, selectedFile]" class="btn btn-danger btn-md" (click)="onNoClick()">Cancelar</button></div>
+                        <div class="p-2"><button [mat-dialog-close]="[true, selectedFile]" class="btn btn-success btn-md" cdkFocusInitial
+                        [disabled]="!selectedFile">Aceptar</button></div>
+                </div>
+            </div>
+        </div>      
+    </div><!-- fin columna -->
+</div><!-- fin row -->

--- a/src/app/componentes/subir-plantilla-informe-final/dialogPlantilla.html
+++ b/src/app/componentes/subir-plantilla-informe-final/dialogPlantilla.html
@@ -7,7 +7,7 @@
             <div class="card-body text-gray-800" style="text-align: center;">  
 
                 <form style="width: 100%;">
-                    <span class="file-name">{{selectedFile?.name}}</span>
+                    <span class="file-name">{{selectedFile?.name}}</span><br>
                     <button type="button" class="btn btn-primary btn-md" (click)="fileInput.click()">Elegir Archivo</button>
                     <input hidden (change)="onFileSelected($event)" #fileInput type="file" required>                    
                 </form>

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
@@ -1,3 +1,3 @@
-<button class="btn btn-primary btn-md " (click)="subir_archivos()">
+<button type="button" class="btn btn-primary btn-md " (click)="subir_archivos()">
     Subir
 </button>

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="nombre_archivo != ''">
-    Archivo subido: {{nombre_archivo}}
+    Archivo a subir: {{nombre_archivo}}
 </div>
 <button type="button" class="btn btn-primary btn-md " (click)="subir_archivos()">
     Subir

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
@@ -1,0 +1,3 @@
+<button class="btn btn-primary btn-md " (click)="subir_archivos()">
+    Subir
+</button>

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.html
@@ -1,3 +1,6 @@
+<div *ngIf="nombre_archivo != ''">
+    Archivo subido: {{nombre_archivo}}
+</div>
 <button type="button" class="btn btn-primary btn-md " (click)="subir_archivos()">
     Subir
 </button>

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.spec.ts
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SubirPlantillaInformeFinalComponent } from './subir-plantilla-informe-final.component';
+
+describe('SubirPlantillaInformeFinalComponent', () => {
+  let component: SubirPlantillaInformeFinalComponent;
+  let fixture: ComponentFixture<SubirPlantillaInformeFinalComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SubirPlantillaInformeFinalComponent]
+    });
+    fixture = TestBed.createComponent(SubirPlantillaInformeFinalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnInit, Output, EventEmitter } from '@angular/core';
 import { MatDialog, MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { FormsModule } from '@angular/forms';
@@ -29,8 +29,10 @@ export class SubirPlantillaInformeFinalComponent {
   @Input() id_encargado: number = -1;
   @Input() id_carrera: number = -1;
 
+  @Output() key_event = new EventEmitter<string>();
+  @Output() file_plantilla_event = new EventEmitter<File>();
+
   observando!: Observable<any>
-  codigobase64!: any;
 
   constructor(public dialog: MatDialog, private _snackBar: MatSnackBar, private archivo_service: ArchivosService, private router: Router,) { }
 
@@ -50,7 +52,6 @@ export class SubirPlantillaInformeFinalComponent {
   }
 
   subir_archivos() {
-
     let formatos = ["pdf", "doc", "docx"]
     const dialogRef = this.dialog.open(Dialog3, {
       width: '400px',
@@ -80,12 +81,14 @@ export class SubirPlantillaInformeFinalComponent {
           return;
         }
 
-        let _data: any = {};
 
         let _filename = file.name.toLowerCase();
         let file_ext = _filename.slice((_filename.lastIndexOf(".") - 1 >>> 0) + 2)
 
-        let key: string = uuidv4() + "." + file_ext;
+        // wait for 1 second and then emit event
+        
+        this.key_event.emit(uuidv4() + "." + file_ext);
+        this.file_plantilla_event.emit(file);
       });
     });
   }

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
@@ -26,13 +26,10 @@ export interface DialogData {
 })
 export class SubirPlantillaInformeFinalComponent {
 
-  @Input() id_encargado: number = -1;
-  @Input() id_carrera: number = -1;
-
   @Output() key_event = new EventEmitter<string>();
   @Output() file_plantilla_event = new EventEmitter<File>();
 
-  observando!: Observable<any>
+  nombre_archivo: string = "";
 
   constructor(public dialog: MatDialog, private _snackBar: MatSnackBar, private archivo_service: ArchivosService, private router: Router,) { }
 
@@ -83,6 +80,7 @@ export class SubirPlantillaInformeFinalComponent {
 
 
         let _filename = file.name.toLowerCase();
+        this.nombre_archivo = _filename;
         let file_ext = _filename.slice((_filename.lastIndexOf(".") - 1 >>> 0) + 2)
 
         // wait for 1 second and then emit event

--- a/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
+++ b/src/app/componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component.ts
@@ -1,0 +1,115 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { FormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { NgFor } from '@angular/common';
+import { CommonModule } from '@angular/common'
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ArchivosService } from '../../servicios/archivos/archivos.service';
+import { Router } from '@angular/router';
+import { EmitType } from '@syncfusion/ej2-base';
+
+import { v4 as uuidv4 } from 'uuid';
+import { Observable, Subscriber } from 'rxjs';
+
+export interface DialogData {
+
+}
+
+@Component({
+  selector: 'app-subir-plantilla-informe-final',
+  templateUrl: './subir-plantilla-informe-final.component.html',
+  styleUrls: ['./subir-plantilla-informe-final.component.scss']
+})
+export class SubirPlantillaInformeFinalComponent {
+
+  @Input() id_encargado: number = -1;
+  @Input() id_carrera: number = -1;
+
+  observando!: Observable<any>
+  codigobase64!: any;
+
+  constructor(public dialog: MatDialog, private _snackBar: MatSnackBar, private archivo_service: ArchivosService, private router: Router,) { }
+
+  readfile(file: File, subscriber: Subscriber<any>) {
+    const filereader = new FileReader()
+
+    filereader.readAsDataURL(file)
+
+    filereader.onload = () => {
+      subscriber.next(filereader.result);
+      subscriber.complete;
+    }
+    filereader.onerror = () => {
+      subscriber.error()
+      subscriber.complete();
+    }
+  }
+
+  subir_archivos() {
+
+    let formatos = ["pdf", "doc", "docx"]
+    const dialogRef = this.dialog.open(Dialog3, {
+      width: '400px',
+      enterAnimationDuration: "100ms",
+      exitAnimationDuration: "100ms",
+    });
+
+    dialogRef.afterClosed().subscribe((result: any) => {
+      if (!result || !result[0]) {
+        return;
+      }
+      let [, file] = result;
+      if (file.size > 10000000) {
+        this._snackBar.open("Este Archivo es Demasiado Grande", "Cerrar", {
+          panelClass: ['red-snackbar'],
+          duration: 3000
+        });
+        return
+      }
+
+      this.archivo_service.checkFileType(file, formatos).then((type_file: boolean) => {
+        if (!type_file) {
+          this._snackBar.open("Archivo con formato incorrecto", "Cerrar", {
+            panelClass: ['red-snackbar'],
+            duration: 3000
+          });
+          return;
+        }
+
+        let _data: any = {};
+
+        let _filename = file.name.toLowerCase();
+        let file_ext = _filename.slice((_filename.lastIndexOf(".") - 1 >>> 0) + 2)
+
+        let key: string = uuidv4() + "." + file_ext;
+      });
+    });
+  }
+}
+
+@Component({
+  selector: 'app-dialogPlantilla',
+  templateUrl: 'dialogPlantilla.html',
+  standalone: true,
+  imports: [MatDialogModule, MatFormFieldModule, MatInputModule, FormsModule, MatButtonModule, MatSelectModule, CommonModule,
+    NgFor],
+})
+export class Dialog3 {
+  selectedFile: File | null = null;
+
+  constructor(public dialogRef: MatDialogRef<Dialog3>, @Inject(MAT_DIALOG_DATA) public data: DialogData) { }
+
+  onFileSelected(event: any): void {
+    this.selectedFile = event.target.files[0] ?? null;
+    console.log(this.selectedFile)
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+}

--- a/src/app/servicios/encargado/config-practica/config.service.ts
+++ b/src/app/servicios/encargado/config-practica/config.service.ts
@@ -121,20 +121,37 @@ export class ConfigService {
         return this._http.request(req);
     }
 
-    crearConfigInforme(id_config_practica: number, tipo_informe: string, archivo_o_encuesta: string = "", tipo_archivo: string = "", plantilla: string = "") {
-        const config = {
-            id_config_practica: id_config_practica,
-            tipo_informe: tipo_informe,
-            archivo_o_encuesta,
-            tipo_archivo,
-            plantilla
+    crearConfigInforme(id_config_practica: number, tipo_informe: string, archivo_o_encuesta: string = "", 
+    tipo_archivo: string = "", plantilla: string = "", file_plantilla: File = new File([], "")) {
+
+        if(archivo_o_encuesta == "archivo" && plantilla != ""){
+            const formData:FormData = new FormData()
+            formData.append('id_config_practica', id_config_practica.toString())
+            formData.append('tipo_informe', tipo_informe)
+            formData.append('archivo_o_encuesta', archivo_o_encuesta)
+            formData.append('tipo_archivo', tipo_archivo)
+            formData.append('plantilla', plantilla)
+            formData.append('file_plantilla', file_plantilla)
+            const req = new HttpRequest('POST', `${environment.url_back}/config_informe/crearConArchivo`, formData, {responseType:"json"});
+            return this._http.request(req);
+
         }
+        else{
+            const config = {
+                id_config_practica: id_config_practica,
+                tipo_informe: tipo_informe,
+                archivo_o_encuesta,
+                tipo_archivo,
+                plantilla
+            }
 
-        const req = new HttpRequest('POST', `${environment.url_back}/config_informe/crear`, config, {
-            responseType: 'json'
-        });
+            const req = new HttpRequest('POST', `${environment.url_back}/config_informe/crear`, config, {
+                responseType: 'json'
+            });
+        
 
-        return this._http.request(req);
+            return this._http.request(req);
+        }
     }
 
     actualizarConfigInforme(id_config_practica: number, tipo_informe: string) {

--- a/src/app/servicios/encargado/config-practica/config.service.ts
+++ b/src/app/servicios/encargado/config-practica/config.service.ts
@@ -121,10 +121,13 @@ export class ConfigService {
         return this._http.request(req);
     }
 
-    crearConfigInforme(id_config_practica: number, tipo_informe: string) {
+    crearConfigInforme(id_config_practica: number, tipo_informe: string, archivo_o_encuesta: string = "", tipo_archivo: string = "", plantilla: string = "") {
         const config = {
             id_config_practica: id_config_practica,
-            tipo_informe: tipo_informe
+            tipo_informe: tipo_informe,
+            archivo_o_encuesta,
+            tipo_archivo,
+            plantilla
         }
 
         const req = new HttpRequest('POST', `${environment.url_back}/config_informe/crear`, config, {

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -581,7 +581,7 @@
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" name="plantillaInformeFinal"
                       id="plantillaInformeFinalSI" value="si" formControlName="plantillaInformeFinal">
-                    <label class="form-check-label" for="plantillaInformeFinalSI">Si</label>
+                    <label class="form-check-label mr-2" for="plantillaInformeFinalSI">Si</label>
 
                     <input class="form-check-input" type="radio" name="plantillaInformeFinal"
                       id="plantillaInformeFinalNO" value="no" formControlName="plantillaInformeFinal">
@@ -590,8 +590,28 @@
                   <br>
                   <br>
                   <div *ngIf="fg.value.plantillaInformeFinal == 'si'">
-                    Subir Plantilla de ejemplo<br>
-                    <app-subir-plantilla-informe-final (key_event)="recibirPlantillaInforme($event)" (file_plantilla_event)="recibirPlantillaInforme($event)"></app-subir-plantilla-informe-final>
+                    <div *ngIf="currentRoute.includes('blanco'); else editandoExistente">
+                      Subir Plantilla de ejemplo<br>
+                      <app-subir-plantilla-informe-final (key_event)="recibirPlantillaInforme($event)"
+                        (file_plantilla_event)="recibirPlantillaInforme($event)"></app-subir-plantilla-informe-final>
+                    </div>
+                  
+                    <ng-template #editandoExistente>
+                      <div *ngIf="link_descarga_plantilla != ''; else editandoAntiguaSinPlantilla">
+                        <button type = "button" class = "btn btn-primary btn-md mb-2">
+                          <a [href]="link_descarga_plantilla" target="_blank" style = "color:white">Descargar plantilla actual</a>
+                        </button><br><br>
+                        Subir nueva plantilla de ejemplo<br>(Reemplazará la plantilla actual)<br>
+                          <app-subir-plantilla-informe-final (key_event)="recibirPlantillaInforme($event)"
+                          (file_plantilla_event)="recibirPlantillaInforme($event)"></app-subir-plantilla-informe-final>
+                      </div>
+                      <ng-template #editandoAntiguaSinPlantilla>
+                        Subir Plantilla de ejemplo<br>
+                        <app-subir-plantilla-informe-final (key_event)="recibirPlantillaInforme($event)"
+                          (file_plantilla_event)="recibirPlantillaInforme($event)"></app-subir-plantilla-informe-final>
+                      </ng-template>
+
+                    </ng-template>
                   </div>
 
                   <div class="row mt-5 mb-3 align-items-end">
@@ -606,7 +626,7 @@
                     <div class="col-4"></div>
                   </div>
                 </form>
-              </form>              
+              </form>
             </div>
           </div> <!-- Fin Configuracion archivo informe final-->
 

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -574,13 +574,15 @@
             Formatos aceptados <br>
             <input type="checkbox" formControlName="horas"> pdf
             <input type="checkbox" formControlName="meses"> word
-            <br>
+            <br><br>
             ¿Desea incluir una plantilla de ejemplo? <br>
-            <input type="checkbox" formControlName="horas"> Si
-            <input type="checkbox" formControlName="meses"> No
+            <input type="radio" name= "radioPlantilla" formControlName="horas"> Si
+            <input type="radio" name= "radioPlantilla" formControlName="meses"> No
             <br>
             <br>
-            Plantilla de ejemplo
+            Subir Plantilla de ejemplo<br>
+            <app-subir-plantilla-informe-final></app-subir-plantilla-informe-final>
+
 
             <div class="row mt-5 mb-3 align-items-end">
               <div class="col-4"></div>

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -153,9 +153,9 @@
                 <div *ngIf="fg.value.informeFinal == 'si'">
                   <p class="mt-2"> Elija el tipo de informe final que desea utilizar</p>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" id="informeFinalCuestionario" value="cuestionario"
+                    <input class="form-check-input" type="radio" id="informeFinalEncuesta" value="encuesta"
                       formControlName="tipoInformeFinal">
-                    <label class="form-check-label" for="informeFinalCuestionario">Cuestionario</label>
+                    <label class="form-check-label" for="informeFinalEncuesta">Encuesta</label>
                   </div>
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" id="informeFinalArchivo" value="archivo"
@@ -365,7 +365,7 @@
           </div><!-- Fin tarjeta inicial-->
 
           <!-------------------------------------------------- CONFIGURACION PREGUNTAS INFORME FINAL -------------------------------------------------------------->
-          <div class="card shadow" *ngIf="estado == 'informe_final_cuestionario'">
+          <div class="card shadow" *ngIf="estado == 'informe_final_encuesta'">
             <div class="card-body text-center">
               <div class="h3 mb-3 font-weight-bold text-gray-800 text-center">
                 Preguntas informe final

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -418,8 +418,8 @@
                     </button>
                   </form>
                 </div>
-              </div>             
-    
+              </div>
+
               <!-- <form (ngSubmit)="avanzarDesdePreguntasFinal()"> -->
 
               <br>
@@ -569,33 +569,43 @@
               <div class="h3 mb-3 font-weight-bold text-gray-800 text-center">
                 Archivo del Informe Final
               </div>
-            
-
-            Formatos aceptados <br>
-            <input type="checkbox" formControlName="horas"> pdf
-            <input type="checkbox" formControlName="meses"> word
-            <br><br>
-            ¿Desea incluir una plantilla de ejemplo? <br>
-            <input type="radio" name= "radioPlantilla" formControlName="horas"> Si
-            <input type="radio" name= "radioPlantilla" formControlName="meses"> No
-            <br>
-            <br>
-            Subir Plantilla de ejemplo<br>
-            <app-subir-plantilla-informe-final></app-subir-plantilla-informe-final>
 
 
-            <div class="row mt-5 mb-3 align-items-end">
-              <div class="col-4"></div>
-              <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="volver()"
-                style="margin-right: 20px;">
-                Volver
-              </button>
-              <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="avanzarDesdePreguntasFinal()">
-                Siguiente
-              </button>
-              <div class="col-4"></div>
+              Formatos aceptados <br>
+              <input type="checkbox" formControlName="horas"> pdf
+              <input type="checkbox" formControlName="meses"> word
+              <br><br>
+              ¿Desea incluir una plantilla de ejemplo? <br>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="plantillaInformeFinalradio" id="plantillaInformeFinalSI"
+                  value="si" formControlName="plantillaInformeFinal">
+                <label class="form-check-label" for="plantillaInformeFinalSI">Si</label>
+
+                <input class="form-check-input" type="radio" name="plantillaInformeFinalradio" id="plantillaInformeFinalNO"
+                  value="no" formControlName="plantillaInformeFinal">
+                <label class="form-check-label" for="plantillaInformeFinalNO">No</label>
+              </div>
+              <br>
+              <br>
+              hola 
+              <div>
+              Subir Plantilla de ejemplo<br>
+                <app-subir-plantilla-informe-final></app-subir-plantilla-informe-final>
+              </div>
+
+
+              <div class="row mt-5 mb-3 align-items-end">
+                <div class="col-4"></div>
+                <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="volver()"
+                  style="margin-right: 20px;">
+                  Volver
+                </button>
+                <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="avanzarDesdePreguntasFinal()">
+                  Siguiente
+                </button>
+                <div class="col-4"></div>
+              </div>
             </div>
-          </div>
           </div> <!-- Fin Configuracion archivo informe final-->
 
           <!-------------------------------------------------- CONFIGURACION DOCUMENTOS -------------------------------------------------------------->

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -569,42 +569,44 @@
               <div class="h3 mb-3 font-weight-bold text-gray-800 text-center">
                 Archivo del Informe Final
               </div>
+              <form *ngIf="flag">
+                <form *ngIf="flag" class="formulario" [formGroup]="fg" (ngSubmit)="onSubmitArchivoInformeFinal()">
 
+                  Formatos aceptados <br>
+                  <input type="checkbox" formControlName="opcion_pdf"> pdf
+                  <input type="checkbox" formControlName="opcion_word"> word
+                  {{fg.value.formatoInformeFinal}}
+                  <br><br>
+                  ¿Desea incluir una plantilla de ejemplo? <br>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="plantillaInformeFinal"
+                      id="plantillaInformeFinalSI" value="si" formControlName="plantillaInformeFinal">
+                    <label class="form-check-label" for="plantillaInformeFinalSI">Si</label>
 
-              Formatos aceptados <br>
-              <input type="checkbox" formControlName="horas"> pdf
-              <input type="checkbox" formControlName="meses"> word
-              <br><br>
-              ¿Desea incluir una plantilla de ejemplo? <br>
-              <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="plantillaInformeFinalradio" id="plantillaInformeFinalSI"
-                  value="si" formControlName="plantillaInformeFinal">
-                <label class="form-check-label" for="plantillaInformeFinalSI">Si</label>
+                    <input class="form-check-input" type="radio" name="plantillaInformeFinal"
+                      id="plantillaInformeFinalNO" value="no" formControlName="plantillaInformeFinal">
+                    <label class="form-check-label" for="plantillaInformeFinalNO">No</label>
+                  </div>
+                  <br>
+                  <br>
+                  <div *ngIf="fg.value.plantillaInformeFinal == 'si'">
+                    Subir Plantilla de ejemplo<br>
+                    <app-subir-plantilla-informe-final (key_event)="recibirPlantillaInforme($event)" (file_plantilla_event)="recibirPlantillaInforme($event)"></app-subir-plantilla-informe-final>
+                  </div>
 
-                <input class="form-check-input" type="radio" name="plantillaInformeFinalradio" id="plantillaInformeFinalNO"
-                  value="no" formControlName="plantillaInformeFinal">
-                <label class="form-check-label" for="plantillaInformeFinalNO">No</label>
-              </div>
-              <br>
-              <br>
-              hola 
-              <div>
-              Subir Plantilla de ejemplo<br>
-                <app-subir-plantilla-informe-final></app-subir-plantilla-informe-final>
-              </div>
-
-
-              <div class="row mt-5 mb-3 align-items-end">
-                <div class="col-4"></div>
-                <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="volver()"
-                  style="margin-right: 20px;">
-                  Volver
-                </button>
-                <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="avanzarDesdePreguntasFinal()">
-                  Siguiente
-                </button>
-                <div class="col-4"></div>
-              </div>
+                  <div class="row mt-5 mb-3 align-items-end">
+                    <div class="col-4"></div>
+                    <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="volver()"
+                      style="margin-right: 20px;">
+                      Volver
+                    </button>
+                    <button class="btn btn-primary btn-user btn-block btn-md col-2" type="submit">
+                      Siguiente
+                    </button>
+                    <div class="col-4"></div>
+                  </div>
+                </form>
+              </form>              
             </div>
           </div> <!-- Fin Configuracion archivo informe final-->
 

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -150,10 +150,21 @@
                     formControlName="informeFinal">
                   <label class="form-check-label" for="informeFinalNO">No</label>
                 </div>
+                <div *ngIf="fg.value.informeFinal == 'si'">
+                  <p class="mt-2"> Elija el tipo de informe final que desea utilizar</p>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" id="informeFinalCuestionario" value="cuestionario"
+                    formControlName="tipoInformeFinal">
+                    <label class="form-check-label" for="informeFinalCuestionario">Cuestionario</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" id="informeFinalArchivo" value="archivo"
+                    formControlName="tipoInformeFinal">
+                    <label class="form-check-label" for="informeFinalArchivo">Archivo</label>
+                  </div>
+                </div>
                 <br>
-                <br>
-
-                <button class="btn btn-primary btn-user btn-md" type="submit">Siguiente</button>
+                <button class="btn btn-primary btn-user btn-md " type="submit">Siguiente</button>
               </form>
             </div>
           </div><!-- Fin tarjeta inicial-->
@@ -354,7 +365,7 @@
           </div><!-- Fin tarjeta inicial-->
 
           <!-------------------------------------------------- CONFIGURACION PREGUNTAS INFORME FINAL -------------------------------------------------------------->
-          <div class="card shadow" *ngIf="estado == 'informe_final'">
+          <div class="card shadow" *ngIf="estado == 'informe_final_cuestionario'">
             <div class="card-body text-center">
               <div class="h3 mb-3 font-weight-bold text-gray-800 text-center">
                 Preguntas informe final

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.html
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.html
@@ -154,12 +154,12 @@
                   <p class="mt-2"> Elija el tipo de informe final que desea utilizar</p>
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" id="informeFinalCuestionario" value="cuestionario"
-                    formControlName="tipoInformeFinal">
+                      formControlName="tipoInformeFinal">
                     <label class="form-check-label" for="informeFinalCuestionario">Cuestionario</label>
                   </div>
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" id="informeFinalArchivo" value="archivo"
-                    formControlName="tipoInformeFinal">
+                      formControlName="tipoInformeFinal">
                     <label class="form-check-label" for="informeFinalArchivo">Archivo</label>
                   </div>
                 </div>
@@ -418,11 +418,11 @@
                     </button>
                   </form>
                 </div>
-              </div>
+              </div>             
+    
+              <!-- <form (ngSubmit)="avanzarDesdePreguntasFinal()"> -->
 
               <br>
-
-              <!-- <form (ngSubmit)="avanzarDesdePreguntasFinal()"> -->
 
               <form *ngIf="flag">
 
@@ -561,7 +561,41 @@
                 <div class="col-4"></div>
               </div>
             </div>
-          </div><!-- Fin tarjeta inicial-->
+          </div><!-- Fin Configuracion preguntas informe final-->
+
+          <!-------------------------------------------------- CONFIGURACION DE ARCHIVO INFORME FINAL -------------------------------------------------------------->
+          <div class="card shadow" *ngIf="estado == 'informe_final_archivo'">
+            <div class="card-body text-center">
+              <div class="h3 mb-3 font-weight-bold text-gray-800 text-center">
+                Archivo del Informe Final
+              </div>
+            
+
+            Formatos aceptados <br>
+            <input type="checkbox" formControlName="horas"> pdf
+            <input type="checkbox" formControlName="meses"> word
+            <br>
+            ¿Desea incluir una plantilla de ejemplo? <br>
+            <input type="checkbox" formControlName="horas"> Si
+            <input type="checkbox" formControlName="meses"> No
+            <br>
+            <br>
+            Plantilla de ejemplo
+
+            <div class="row mt-5 mb-3 align-items-end">
+              <div class="col-4"></div>
+              <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="volver()"
+                style="margin-right: 20px;">
+                Volver
+              </button>
+              <button class="btn btn-primary btn-user btn-block btn-md col-2" (click)="avanzarDesdePreguntasFinal()">
+                Siguiente
+              </button>
+              <div class="col-4"></div>
+            </div>
+          </div>
+          </div> <!-- Fin Configuracion archivo informe final-->
+
           <!-------------------------------------------------- CONFIGURACION DOCUMENTOS -------------------------------------------------------------->
           <div class="card shadow" *ngIf="estado == 'solicitud_documentos'">
             <div class="card-body text-center">
@@ -594,7 +628,8 @@
                   <textarea rows="3" class="form-control input-center text-area" placeholder="Descripción solicitud"
                     formControlName="descripcion_solicitud_documentos"></textarea>
                   <label for="dropdown">Tipo de documento:</label>
-                  <select class="form-select input-center" id="dropdown" placeholder="Tipo documento" formControlName="tipo_solicitud_documentos">
+                  <select class="form-select input-center" id="dropdown" placeholder="Tipo documento"
+                    formControlName="tipo_solicitud_documentos">
                     <option value="pdf">PDF</option>
                     <option value="jpg">JPG</option>
                     <option value="xlsx">Excel</option>

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
@@ -313,6 +313,26 @@ export class ConfiguracionPracticaComponent {
                             //* set preguntas informe
                             if (respuesta.body?.length) { // el encargado seteó preguntas de informe
                                 for (let j = 0; j < respuesta.body.length; j++) {
+                                    if ( (respuesta.body[j]?.tipo_informe).toLowerCase() == "informe final" ){
+                                        if ( (respuesta.body[j]?.archivo_o_encuesta).toLowerCase() == "encuesta" ) {
+                                            this.tipoInformeFinal = "encuesta";
+                                        }
+                                        else if ( (respuesta.body[j]?.archivo_o_encuesta).toLowerCase() == "archivo" ) {
+                                            this.tipoInformeFinal = "archivo";
+                                            if (respuesta.body[j]?.tipo_archivo.includes("pdf")) {
+                                                this.opcion_pdf = true;
+                                            }
+                                            if (respuesta.body[j]?.tipo_archivo.includes("doc")) {
+                                                this.opcion_word = true;
+                                            }
+                                            if (respuesta.body[j]?.plantilla != "" ){
+                                                this.plantillaInformeFinal = "si";
+                                            }
+                                            else {
+                                                this.plantillaInformeFinal = "no";
+                                            }
+                                        }
+                                    }
                                     for (let i = 0; i < respuesta.body[j].pregunta_informes.length; i++) {
                                         if (respuesta.body[j].tipo_informe == "informe final") {
                                             this.lista_preguntas_final.push(respuesta.body[j].pregunta_informes[i].enunciado);

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
@@ -23,6 +23,8 @@ export class ConfiguracionPracticaComponent {
     importada: boolean = false;
     migracion_legal: boolean = true;
     user: any = JSON.parse(localStorage.getItem('auth-user') || "{}").userdata;
+    archivo_plantilla: File | null = null;
+    key_plantilla: string = "";
 
     constructor(private _fb: FormBuilder, private cd: ChangeDetectorRef, @Inject(DOCUMENT) private document: Document,
         private serviceBarra: BarraLateralService, private _snackBar: MatSnackBar, private route: ActivatedRoute,
@@ -103,6 +105,9 @@ export class ConfiguracionPracticaComponent {
     informeFinal: string;
     tipoInformeFinal: string;
     formatoInformeFinal: string;
+    opcion_pdf: boolean = false;
+    opcion_word: boolean = false;
+
     plantillaInformeFinal: string;
     preguntaFORM = new FormControl('')
 
@@ -231,6 +236,8 @@ export class ConfiguracionPracticaComponent {
                 tipoInformeFinal: new FormControl(this.tipoInformeFinal),
                 formatoInformeFinal: new FormControl(this.formatoInformeFinal),
                 plantillaInformeFinal: new FormControl(this.plantillaInformeFinal),
+                opcion_pdf: new FormControl(this.opcion_pdf),
+                opcion_word: new FormControl(this.opcion_word),
                 //pregunta: this.preguntaFORM,
 
                 preguntaFORM: this.pregunta,
@@ -400,6 +407,8 @@ export class ConfiguracionPracticaComponent {
                                                                 tipoInformeFinal: new FormControl(this.tipoInformeFinal),
                                                                 formatoInformeFinal: new FormControl(this.formatoInformeFinal),
                                                                 plantillaInformeFinal: new FormControl(this.plantillaInformeFinal),
+                                                                opcion_pdf: new FormControl(this.opcion_pdf),
+                                                                opcion_word: new FormControl(this.opcion_word),
                                                                 //pregunta: this.preguntaFORM,
 
                                                                 preguntaFORM: this.pregunta,
@@ -501,8 +510,6 @@ export class ConfiguracionPracticaComponent {
         this.frecuenciaInformes = this.fg.value.frecuenciaInformes;
         this.informeFinal = this.fg.value.informeFinal;
         this.tipoInformeFinal = this.fg.value.tipoInformeFinal;
-        this.formatoInformeFinal = this.fg.value.formatoInformeFinal;
-        this.plantillaInformeFinal = this.fg.value.plantillaInformeFinal;
         this.opcion_horas = this.arregloHoras.value;
         this.opcion_meses = this.arregloMeses.value;
 
@@ -633,6 +640,23 @@ export class ConfiguracionPracticaComponent {
 
         this.arregloOpcionesPreguntas.clear();
         this.pregunta = "";
+    }
+
+    onSubmitArchivoInformeFinal() {
+        this.formatoInformeFinal = "";
+        if (this.fg.value.opcion_pdf == true) {
+            this.formatoInformeFinal += "pdf,";
+        }
+        if (this.fg.value.opcion_word == true) {
+            this.formatoInformeFinal += "doc,docx,";
+        }
+        if (this.formatoInformeFinal.slice(-1) == ",") {
+            this.formatoInformeFinal = this.formatoInformeFinal.slice(0, -1);
+        }
+        console.log(this.formatoInformeFinal);
+        this.plantillaInformeFinal = this.fg.value.plantillaInformeFinal;
+
+        this.avanzarDesdePreguntasFinal()
     }
 
     onSubmitAddPreguntaEncuesta() {
@@ -1362,6 +1386,16 @@ export class ConfiguracionPracticaComponent {
                 console.log("Solicitud de documento eliminada exitosamente");
             }
         });
+    }
+
+    recibirPlantillaInforme(data: any){
+        if (typeof(data) == "string"){
+            this.key_plantilla = data;
+        }
+        else if (typeof(data) == "object"){
+            this.archivo_plantilla = data;
+        }            
+        console.log("key: ", this.key_plantilla, "archivo: ", this.archivo_plantilla);
     }
 
 }

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
@@ -101,11 +101,8 @@ export class ConfiguracionPracticaComponent {
     meses: boolean;
     frecuenciaInformes: string;
     informeFinal: string;
+    tipoInformeFinal: string;
     preguntaFORM = new FormControl('')
-
-    aptitudFORM = new FormControl('')
-
-    aptitud: string;
 
     nombre_solicitud_documentos: string;
     descripcion_solicitud_documentos: string;
@@ -119,7 +116,6 @@ export class ConfiguracionPracticaComponent {
     habilitarHoras: boolean = false;
     habilitarMeses: boolean = false;
 
-    //lista_aptitudes: string[] = [];
 
     lista_preguntas_avance: string[] = [];
     tipos_preguntas_avance: string[] = [];
@@ -214,6 +210,7 @@ export class ConfiguracionPracticaComponent {
             this.frecuenciaInformes = "";
             this.informeFinal = "";
             this.tipo_solicitud_documentos = "pdf";
+            this.tipoInformeFinal = "";
 
             this.fg = this._fb.group({
                 opcion_preguntaFORM: this.opcion_pregunta, //para poder definir tipo de pregunta
@@ -227,10 +224,10 @@ export class ConfiguracionPracticaComponent {
                 meses: new FormControl(this.meses),
                 frecuenciaInformes: new FormControl(this.frecuenciaInformes, Validators.required),
                 informeFinal: new FormControl(this.informeFinal, Validators.required),
+                tipoInformeFinal: new FormControl(this.tipoInformeFinal),
                 //pregunta: this.preguntaFORM,
 
                 preguntaFORM: this.pregunta,
-                aptitudFORM: this.aptitud,
 
                 arregloOpcionesPreguntas: this._fb.array([]),
                 arregloHoras: this._fb.array([]),
@@ -381,23 +378,6 @@ export class ConfiguracionPracticaComponent {
                                                         this.lista_tipo_solicitud_documentos.push(respuesta.body[i].tipo_archivo);
                                                     }
 
-                                                    //* set aptitudes
-                                                    /*
-                                                    this.serviceComplete.getAptitudes(id_config_practica).subscribe({
-                                                        next: (data: any) => {
-                                                            respuesta = { ...respuesta, ...data }
-                                                        },
-                                                        error: (error: any) => {
-                                                            this._snackBar.open("Error al buscar aptitudes", "Cerrar", {
-                                                                duration: 3000,
-                                                                panelClass: ['red-snackbar']
-                                                            });
-                                                            console.log("Error al buscar aptitudes", error);
-                                                        },
-                                                        complete: () => {
-                                                            console.log("request aptitudes:", respuesta.body);
-                                                            this.lista_aptitudes = respuesta.body.opciones.split(";;");
-
                                                             //* set formulario
                                                             this.fg = this._fb.group({
                                                                 opcion_preguntaFORM: this.opcion_pregunta, //para poder definir tipo de pregunta
@@ -411,10 +391,10 @@ export class ConfiguracionPracticaComponent {
                                                                 meses: new FormControl(this.meses),
                                                                 frecuenciaInformes: new FormControl(this.frecuenciaInformes, Validators.required),
                                                                 informeFinal: new FormControl(this.informeFinal, Validators.required),
+                                                                tipoInformeFinal: new FormControl(this.tipoInformeFinal),
                                                                 //pregunta: this.preguntaFORM,
 
                                                                 preguntaFORM: this.pregunta,
-                                                                aptitudFORM: this.aptitud,
 
                                                                 arregloOpcionesPreguntas: this._fb.array([]),
                                                                 arregloHoras: this._fb.array([]),
@@ -426,9 +406,6 @@ export class ConfiguracionPracticaComponent {
                                                                 tipo_solicitud_documentos: new FormControl(this.tipo_solicitud_documentos),
                                                             });
                                                             this.flag = true;
-                                                        }
-                                                    });
-                                                    */
                                                 }
                                             });
                                         }
@@ -515,6 +492,7 @@ export class ConfiguracionPracticaComponent {
         this.meses = this.fg.value.meses;
         this.frecuenciaInformes = this.fg.value.frecuenciaInformes;
         this.informeFinal = this.fg.value.informeFinal;
+        this.tipoInformeFinal = this.fg.value.tipoInformeFinal;
         this.opcion_horas = this.arregloHoras.value;
         this.opcion_meses = this.arregloMeses.value;
 
@@ -530,9 +508,14 @@ export class ConfiguracionPracticaComponent {
             this.estado = "solicitud_documentos";
             //console.log("documentos");
         }
-        else if (this.frecuenciaInformes == "sinAvance" && this.informeFinal == "si") {
-            this.estado = "informe_final";
-            //console.log("informe final");
+        else if (this.frecuenciaInformes == "sinAvance" && this.informeFinal == "si" ) {
+            if (this.tipoInformeFinal == "cuestionario"){
+                this.estado = "informe_final_cuestionario";
+            }
+            else if (this.tipoInformeFinal == "archivo"){
+                this.estado = "informe_final_archivo";
+            }            
+            console.log("informe final", this.tipoInformeFinal);
         }
         else if (this.frecuenciaInformes != "sinAvance") {
             this.estado = "informe_avance";
@@ -690,16 +673,6 @@ export class ConfiguracionPracticaComponent {
         this.pregunta = "";
     }
 
-    /*
-    onSubmitAddAptitud() {
-        this.aptitud = this.fg.value.aptitudFORM;
-        this.lista_aptitudes.push(this.aptitud);
-        console.log(this.lista_aptitudes);
-
-        this.aptitud = "";
-    }
-    */
-
     onSubmitAddPreguntaSupervisor() {
         //this.lista_opciones_preguntas = [];
         this.pregunta = this.fg.value.preguntaFORM;
@@ -787,7 +760,12 @@ export class ConfiguracionPracticaComponent {
 
     avanzarDesdePreguntasAvance() {
         if (this.informeFinal == "si") {
-            this.estado = "informe_final";
+            if (this.tipoInformeFinal == "cuestionario"){
+                this.estado = "informe_final_cuestionario";
+            }
+            else if (this.tipoInformeFinal == "archivo"){
+                this.estado = "informe_final_archivo";
+            }
         }
         else {
             this.estado = "solicitud_documentos";
@@ -813,12 +791,6 @@ export class ConfiguracionPracticaComponent {
         this.printForm();
     }
 
-    /*
-    avanzarDesdeAptitud() {
-        this.estado = "preguntas_supervisor";
-        this.printForm();
-    }
-    */
 
     avanzarDesdePreguntasSupervisor() {
         this.estado = "fin_configuracion";
@@ -835,7 +807,7 @@ export class ConfiguracionPracticaComponent {
         }
 
         //volver desde preguntas final
-        if (this.estado == "informe_final") {
+        if (this.estado == "informe_final_cuestionario" || this.estado == "informe_final_archivo") {
             if (this.frecuenciaInformes == "sinAvance") {
                 this.estado = "configuracion_general";
             }
@@ -846,7 +818,12 @@ export class ConfiguracionPracticaComponent {
         //volver desde solicitud de documentos
         else if (this.estado == "solicitud_documentos") {
             if (this.informeFinal == "si") {
-                this.estado = "informe_final";
+                if (this.tipoInformeFinal == "cuestionario"){
+                    this.estado = "informe_final_cuestionario";
+                }
+                else if (this.tipoInformeFinal == "archivo"){
+                    this.estado = "informe_final_archivo";
+                }
             }
             else if (this.frecuenciaInformes == "sinAvance") {
                 this.estado = "configuracion_general";
@@ -859,17 +836,6 @@ export class ConfiguracionPracticaComponent {
         else if (this.estado == "encuesta_final") {
             this.estado = "solicitud_documentos";
         }
-        //volver desde agregar ramos
-        /*
-        else if (this.estado == "agregar_ramos") {
-          this.estado = "encuesta_final";
-        }
-        */
-       /*
-        else if (this.estado == "aptitudes") {
-            this.estado = "encuesta_final";
-        }
-        */
         //volver desde preguntas supervisor
         else if (this.estado == "preguntas_supervisor") {
             //this.estado = "agregar_ramos";
@@ -936,13 +902,6 @@ export class ConfiguracionPracticaComponent {
         this.migracion_legal = false;
     }
 
-    /*
-    eliminarAptitud(index: number) {
-        console.log("eliminando aptitud", index);
-        this.lista_aptitudes.splice(index, 1);
-        this.migracion_legal = false;
-    }
-    */
 
     mandarDatos() { //se estan apilando los snackbars positivos (dejar los negativos)
         let tipo_request: string;
@@ -985,16 +944,6 @@ export class ConfiguracionPracticaComponent {
                 });
             }
         });
-
-        //eliminar actuales
-        //this.delConfigInforme(this.config.id);
-        //this.delPreguntaSupervisor(this.config.id);
-        //this.delSolicitudDocumento(this.config.id);
-        //this.delPreguntaEncuestaFinal(this.config.id);
-        //this.delModalidad(this.config.id);
-        //for (let i = 0; i < this.ids_config_informe.length; i++) {
-        //    this.delPreguntaInforme(this.ids_config_informe[i]);
-        //}
 
         //crear nuevos (copias)
         this.serviceComplete.crearConfigPractica(nombre, frecuencia, final, +this.user.encargado.id_carrera).subscribe({
@@ -1074,21 +1023,6 @@ export class ConfiguracionPracticaComponent {
     }
 
     crearConfigPractica(nombre: string, frecuencia: string, final: string) {
-
-        /*
-        //agregando pregunta aptitudes/evaluacion a preguntas supervisor
-        var opciones_aptitudes = ""
-        for (let i = 0; i < this.lista_aptitudes.length; i++) {
-            opciones_aptitudes = opciones_aptitudes + this.lista_aptitudes[i]
-            opciones_aptitudes = opciones_aptitudes + ";;"
-        }
-        opciones_aptitudes = opciones_aptitudes.slice(0, -2);
-
-        this.lista_preguntas_supervisor.push("Evalúe entre 1 y 5 las siguientes aptitudes del practicante");
-        this.tipos_preguntas_supervisor.push("evaluacion");
-        this.lista_opciones_preguntas_supervisor.push(opciones_aptitudes);
-        this.lista_fija_preguntas_supervisor.push(true);
-        */
 
         let respuesta: any = {};
 

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
@@ -102,6 +102,8 @@ export class ConfiguracionPracticaComponent {
     frecuenciaInformes: string;
     informeFinal: string;
     tipoInformeFinal: string;
+    formatoInformeFinal: string;
+    plantillaInformeFinal: string;
     preguntaFORM = new FormControl('')
 
     nombre_solicitud_documentos: string;
@@ -211,6 +213,8 @@ export class ConfiguracionPracticaComponent {
             this.informeFinal = "";
             this.tipo_solicitud_documentos = "pdf";
             this.tipoInformeFinal = "";
+            this.formatoInformeFinal = "";
+            this.plantillaInformeFinal = "";
 
             this.fg = this._fb.group({
                 opcion_preguntaFORM: this.opcion_pregunta, //para poder definir tipo de pregunta
@@ -225,6 +229,8 @@ export class ConfiguracionPracticaComponent {
                 frecuenciaInformes: new FormControl(this.frecuenciaInformes, Validators.required),
                 informeFinal: new FormControl(this.informeFinal, Validators.required),
                 tipoInformeFinal: new FormControl(this.tipoInformeFinal),
+                formatoInformeFinal: new FormControl(this.formatoInformeFinal),
+                plantillaInformeFinal: new FormControl(this.plantillaInformeFinal),
                 //pregunta: this.preguntaFORM,
 
                 preguntaFORM: this.pregunta,
@@ -392,6 +398,8 @@ export class ConfiguracionPracticaComponent {
                                                                 frecuenciaInformes: new FormControl(this.frecuenciaInformes, Validators.required),
                                                                 informeFinal: new FormControl(this.informeFinal, Validators.required),
                                                                 tipoInformeFinal: new FormControl(this.tipoInformeFinal),
+                                                                formatoInformeFinal: new FormControl(this.formatoInformeFinal),
+                                                                plantillaInformeFinal: new FormControl(this.plantillaInformeFinal),
                                                                 //pregunta: this.preguntaFORM,
 
                                                                 preguntaFORM: this.pregunta,
@@ -493,6 +501,8 @@ export class ConfiguracionPracticaComponent {
         this.frecuenciaInformes = this.fg.value.frecuenciaInformes;
         this.informeFinal = this.fg.value.informeFinal;
         this.tipoInformeFinal = this.fg.value.tipoInformeFinal;
+        this.formatoInformeFinal = this.fg.value.formatoInformeFinal;
+        this.plantillaInformeFinal = this.fg.value.plantillaInformeFinal;
         this.opcion_horas = this.arregloHoras.value;
         this.opcion_meses = this.arregloMeses.value;
 

--- a/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
+++ b/src/app/vistas/configuracion-practica/configuracion-practica.component.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, ParamMap, Router, Event, NavigationStart, NavigationEnd, NavigationError } from '@angular/router';
 import { ChangeDetectorRef, Component, Inject } from '@angular/core';
-import { FormControl, FormGroup, FormArray, FormBuilder, Validators } from '@angular/forms';
+import { FormControl, FormGroup, FormArray, FormBuilder, Validators, isFormRecord } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table'
 
 import { BarraLateralService } from 'src/app/servicios/encargado/barra-lateral/barra-lateral.service';
@@ -25,6 +25,7 @@ export class ConfiguracionPracticaComponent {
     user: any = JSON.parse(localStorage.getItem('auth-user') || "{}").userdata;
     archivo_plantilla: File | undefined;
     key_plantilla: string = "";
+    link_descarga_plantilla:string = "";
 
     constructor(private _fb: FormBuilder, private cd: ChangeDetectorRef, @Inject(DOCUMENT) private document: Document,
         private serviceBarra: BarraLateralService, private _snackBar: MatSnackBar, private route: ActivatedRoute,
@@ -327,6 +328,8 @@ export class ConfiguracionPracticaComponent {
                                             }
                                             if (respuesta.body[j]?.plantilla != "" ){
                                                 this.plantillaInformeFinal = "si";
+                                                this.key_plantilla = respuesta.body[j].plantilla;
+                                                this.link_descarga_plantilla = "https://d2v9ocre132gvc.cloudfront.net/" + this.key_plantilla;
                                             }
                                             else {
                                                 this.plantillaInformeFinal = "no";

--- a/src/app/vistas/vista-configs-practica/vista-configs-practica.component.html
+++ b/src/app/vistas/vista-configs-practica/vista-configs-practica.component.html
@@ -230,11 +230,16 @@
                                                         <p>Informe final: </p>
                                                         <div class="form-check form-check-inline">
                                                             <input class="form-check-input" type="radio" id="informeFinalSI" value="si" formControlName="informe_final">
-                                                            <label class="form-check-label" for="informeFinalSI">Si</label>
+                                                            <label class="form-check-label" for="informeFinalSI">Sí</label>
                                                         </div>
                                                         <div class="form-check form-check-inline">
                                                         	<input class="form-check-input" type="radio" id="informeFinalNO" value="no" formControlName="informe_final">
                                                         	<label class="form-check-label" for="informeFinalNO">No</label>
+                                                        </div>
+                                                        <!--Seccion para elegir el tipo de informe final en caso de que se elija Si-->
+                                                        <div *ngIf="crearForm.value.informe_final=='si'">
+                                                            
+                                                            
                                                         </div>
                                                     </form>
                                                 </div>

--- a/src/app/vistas/vista-configs-practica/vista-configs-practica.component.ts
+++ b/src/app/vistas/vista-configs-practica/vista-configs-practica.component.ts
@@ -39,7 +39,7 @@ export class VistaConfigsPracticaComponent implements OnInit{
         ],
         "config_informes": [
             {
-                "tipo_informe": "Informe avance",
+                "tipo_informe": "informe avance",
                 "pregunta_informes": [
                     {
                         "enunciado": "Describa el trabajo realizado",
@@ -49,7 +49,7 @@ export class VistaConfigsPracticaComponent implements OnInit{
                 ]
             },
             {
-                "tipo_informe": "Informe final",
+                "tipo_informe": "informe final",
                 "archivo_o_encuesta": "encuesta",
                 "pregunta_informes": [
                     {

--- a/src/app/vistas/vista-configs-practica/vista-configs-practica.component.ts
+++ b/src/app/vistas/vista-configs-practica/vista-configs-practica.component.ts
@@ -50,6 +50,7 @@ export class VistaConfigsPracticaComponent implements OnInit{
             },
             {
                 "tipo_informe": "Informe final",
+                "archivo_o_encuesta": "encuesta",
                 "pregunta_informes": [
                     {
                         "enunciado": "Que conocimientos adquirió trabajando en la empresa",
@@ -248,24 +249,49 @@ export class VistaConfigsPracticaComponent implements OnInit{
     crearConfigInforme(id_config_practica: number, tipoInforme: string, preguntas: any) {
         let respuesta: any = {};
 
-        this.service.crearConfigInforme(id_config_practica, tipoInforme).subscribe({
-            next: (data: any) => {
-                respuesta = { ...respuesta, ...data }
-            },
-            error: (error: any) => {
-                this.snackBar.open("Error al guardar configuracion de informe", "Cerrar", {
-                    duration: 3500,
-                    panelClass: ['red-snackbar']
-                });
-                console.log("Error al guardar configuracion de informe", error);
-            },
-            complete: () => {
-                //console.log("BUSACR EL ID: ", respuesta);
-                for (let i = 0; i < preguntas.length; i++) {
-                    this.crearPreguntaInforme(respuesta.body.id, preguntas[i].enunciado, preguntas[i].tipo_respuesta, preguntas[i].opciones);
+        if (tipoInforme == "Informe final") {
+            this.service.crearConfigInforme(id_config_practica, tipoInforme, this.practica_default.config_informes[1].archivo_o_encuesta).subscribe({
+                next: (data: any) => {
+                    respuesta = { ...respuesta, ...data }
+                },
+                error: (error: any) => {
+                    this.snackBar.open("Error al guardar configuracion de informe", "Cerrar", {
+                        duration: 3500,
+                        panelClass: ['red-snackbar']
+                    });
+                    console.log("Error al guardar configuracion de informe", error);
+                },
+                complete: () => {
+                    //console.log("BUSACR EL ID: ", respuesta);
+                    for (let i = 0; i < preguntas.length; i++) {
+                        this.crearPreguntaInforme(respuesta.body.id, preguntas[i].enunciado, preguntas[i].tipo_respuesta, preguntas[i].opciones);
+                    }
                 }
-            }
-        });
+            });
+            
+        }
+        else{
+            this.service.crearConfigInforme(id_config_practica, tipoInforme).subscribe({
+                next: (data: any) => {
+                    respuesta = { ...respuesta, ...data }
+                },
+                error: (error: any) => {
+                    this.snackBar.open("Error al guardar configuracion de informe", "Cerrar", {
+                        duration: 3500,
+                        panelClass: ['red-snackbar']
+                    });
+                    console.log("Error al guardar configuracion de informe", error);
+                },
+                complete: () => {
+                    //console.log("BUSACR EL ID: ", respuesta);
+                    for (let i = 0; i < preguntas.length; i++) {
+                        this.crearPreguntaInforme(respuesta.body.id, preguntas[i].enunciado, preguntas[i].tipo_respuesta, preguntas[i].opciones);
+                    }
+                }
+            });
+        }
+
+        
     }
 
     crearPreguntaInforme(id_config_informe: number, pregunta: string, tipo_pregunta: string, opciones: string) {


### PR DESCRIPTION
Probar con PR 115 del node backend https://github.com/LogiLinkP/praxus-node-backend/pull/115

Todos los cambios son relacionados a configuracion-practica (vista del encargado) - todavía no se aplica a edición rápida o a vista-configs-practica.

- [x] Al crear una config practica nueva, si uno selecciona que sí tenga informe final, ahora se pide elegir si el informe final debe ser encuesta o archivo.
- [ ] Si se selecciona encuesta, muestra lo mismo de siempre al hacer siguiente. Si se selecciona "archivo", al hacer siguiente ahora muestra una tarjeta distinta, donde se pide elegir el formato y se puede subir una plantilla.
- [x] Para subir plantilla, se abre un modal que permite seleccionar el archivo.
- [x] Luego, al terminar la configuración, se guarda en la base de datos la nueva config práctica, y en la tabla config_informe, queda una nueva fila de "informe final" que tiene el valor "archivo" en la nueva columna "archivo_o_encuesta"; tiene el valor "pdf,doc,docx" (dependiendo de lo que se haya seleccionado) en la nueva columna "tipo_archivo" y tiene una string con el nombre del archivo en el server de amazon en la nueva columna "plantilla" (en caso de elegirse que sí tenga plantilla).
- [ ] También se puede probar que no hay errores al seleccionar que no tenga plantilla, o que queda con el valor "encuesta" al seleccionar ese tipo en la config_practica.
- [ ] La plantilla debería quedar guardada en el server de amazon (por ahora sólo Harold puede confirmarlo).
