### PR TITLE
[HDU 17.1] Verificación de correo de usuario de estudiante

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -34,6 +34,7 @@ import { InfoYEvaluacionEstudianteComponent } from "./vistas/wizards/info-y-eval
 import { DetalleEstudianteComponent } from "./vistas/wizards/detalle-estudiante/detalle-estudiante.component";
 import { ConfigPracticaComponent } from './vistas/wizards/config-practica/config-practica.component';
 import { AptitudesComponent } from './vistas/aptitudes/aptitudes.component';
+import { ConfirmacionUsuarioComponent } from './vistas/confirmacion-usuario/confirmacion-usuario.component';
 
 import { environment } from 'src/environments/environment';
 import { PerfilComponent } from './vistas/perfil/perfil.component';
@@ -99,6 +100,7 @@ const routes: Routes = [
   { path: 'perfil', component: PerfilComponent },
   { path: "plagios/:id_practica", component: PlagiosComponent },
   { path: 'documentacion', component: DocumentacionComponent},
+  { path: 'usuario/confirmacion', component: ConfirmacionUsuarioComponent },
   { path: '**', component: PnfComponent },
 
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -91,6 +91,7 @@ import { ComentariosModalComponent } from './componentes/comentarios-modal/comen
 import { DocumentacionComponent } from './vistas/documentacion/documentacion.component';
 import { SubirDocumentoEncargadoComponent } from './componentes/subir-documento-encargado/subir-documento-encargado.component';
 import { SubirPlantillaInformeFinalComponent } from './componentes/subir-plantilla-informe-final/subir-plantilla-informe-final.component';
+import { ConfirmacionUsuarioComponent } from './vistas/confirmacion-usuario/confirmacion-usuario.component';
 
 @NgModule({
   declarations: [
@@ -148,6 +149,7 @@ import { SubirPlantillaInformeFinalComponent } from './componentes/subir-plantil
     DocumentacionComponent,
     SubirDocumentoEncargadoComponent,
     SubirPlantillaInformeFinalComponent,
+    ConfirmacionUsuarioComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/servicios/usuario/usuario.service.ts
+++ b/src/app/servicios/usuario/usuario.service.ts
@@ -33,4 +33,9 @@ export class UsuarioService {
     return this.http.request(req);
   }
 
+  get_usuario_encriptado(token: string, iv: string): Observable<any>{
+    const req = new HttpRequest('GET', `${environment.url_back}/usuario/confirmar_correo?token=${token}&iv=${iv}`);
+    return this.http.request(req);
+  }
+
 }

--- a/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.html
+++ b/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.html
@@ -1,0 +1,45 @@
+<div id="wrapper">
+    <!-- Content Wrapper -->
+    <div id="content-wrapper" class="d-flex flex-column">
+        <!-- Main Content -->
+        <div id="content" class="main-content">
+            <!-- Begin Page Content -->
+            <div class="container-fluid" style="height: 100vh;">
+                <!-- Page Heading -->
+                <div class="row pt-5">
+                    <div class="col-lg-2"></div>
+                    <!-- Column -->
+                    <div class="col-lg-8">
+                        <!-- Tarjeta inicial-->
+                        <div class="card border-left-primary shadow py-2">
+                            <div class="card-body" *ngIf="correo_confirmado==true; else errorConfirmacion">
+                                <div class="h4 mb-3 font-weight-bold text-gray-800 text-center">
+                                    ¡Gracias por confirmar tu correo!
+                                </div>
+                                <div class="h5 mb-3 text-gray-800 text-center">
+                                    Ahora puedes iniciar sesión con el correo
+                                    {{usuario.correo}}
+                                </div>
+                                <div class="h5 mb-3 text-gray-800 text-center">
+                                    <button class = "btn btn-primary btn-user" >
+                                        <a href = "/"
+                                        style = "color:white">Iniciar sesión</a>
+                                    </button>
+                                </div>
+                            </div>
+                            <ng-template #errorConfirmacion>
+                                <div class="card-body">
+                                    <div class="h4 mb-3 font-weight-bold text-gray-800 text-center">
+                                        ¡Hubo un error al confirmar tu correo!
+                                    </div>
+
+                                    <div class="h5 mb-3 text-gray-800 text-center">
+                                        Por favor, intenta de nuevo
+                                    </div>
+                                </div>
+                            </ng-template>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>

--- a/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.spec.ts
+++ b/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmacionUsuarioComponent } from './confirmacion-usuario.component';
+
+describe('ConfirmacionUsuarioComponent', () => {
+  let component: ConfirmacionUsuarioComponent;
+  let fixture: ComponentFixture<ConfirmacionUsuarioComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmacionUsuarioComponent]
+    });
+    fixture = TestBed.createComponent(ConfirmacionUsuarioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.ts
+++ b/src/app/vistas/confirmacion-usuario/confirmacion-usuario.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { UsuarioService } from '../../servicios/usuario/usuario.service';
+import { ActivatedRoute } from '@angular/router';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  selector: 'app-confirmacion-usuario',
+  templateUrl: './confirmacion-usuario.component.html',
+  styleUrls: ['./confirmacion-usuario.component.scss']
+})
+export class ConfirmacionUsuarioComponent {
+
+  correo_confirmado: boolean = false;
+  usuario: any = {};
+  
+  constructor(activated_route: ActivatedRoute, private usuario_service: UsuarioService) {
+    let token = "";
+    let iv = "";
+    let response: any = {};
+
+    //obtener token y iv de la url
+    activated_route.queryParams.subscribe(params => {
+      token = params['token'];
+      iv = params['iv'];
+    });
+
+    //obtener usuario
+    this.usuario_service.get_usuario_encriptado(token, iv).subscribe({
+      next: (data: any) => {
+        response = { ...response, ...data };
+      },
+      error: (error: any) => {
+        console.log(error);
+      },
+      complete: () => {
+        if (response) {
+          this.correo_confirmado = true;
+          this.usuario = response.body.userdata;
+          console.log(this.usuario);
+        }
+      }
+    });
+
+   }
+
+
+
+}

--- a/src/app/vistas/registro/registro.component.ts
+++ b/src/app/vistas/registro/registro.component.ts
@@ -109,7 +109,7 @@ export class RegistroComponent implements OnInit {
       complete: () => {
         if (_data.status == 200) {
           this.router.navigate(["/" + environment.ruta_login])
-          this._snackBar.open("Usuario creado correctamente", "Cerrar", {
+          this._snackBar.open("Se ha enviado correo de confirmación para crear al usuario.", "Cerrar", {
             panelClass: ['green-snackbar'],
             duration: 2000
           });


### PR DESCRIPTION
Revisar con [PR 133 en node](https://github.com/LogiLinkP/praxus-node-backend/pull/133)

- [x] Al registrarse, se crea una fila nueva en la tabla usuario, pero queda con el campo "activado" =false
- [x] No se puede loguear con ese usuario hasta que "activado" = true
- [x] Se envía un correo de verificación con un link - al ir a ese link, se lleva a una pantalla que dice que se verificó el usuario
- [x] Una vez verificado, el campo cambia a true y se puede loguear