### PR TITLE
Correcciones gráficas a la vista publicaciones

### DIFF
--- a/src/app/vistas/publicaciones/publicaciones.component.html
+++ b/src/app/vistas/publicaciones/publicaciones.component.html
@@ -44,66 +44,65 @@
                             <div class="card-body">
                                 <p>{{publi?.fecha}}</p>
                                 <p>{{publi?.enunciado}}</p>
-                            </div>
 
-                            <div *ngIf="esalumno==0">
-
-                                <div class="row">
-                                    <div class="col-6">
-                                        <button class="btn btn-primary"
-                                            (click)="inicio_edicion(1, indice, publi.titulo, publi.enunciado, publi.IsFijo)">
-                                            Editar
-                                        </button>
-                                        &nbsp;
-                                        <button class="btn btn-danger" (click)="eliminar(publi.id, 1, indice)">
-                                            Eliminar
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <div class="card shadow mb-4" *ngIf="fixed_edit_flags[indice] == 1">
-                                    <div class="card-header py3">
-                                        <h3 class="m-0 font-weight-bold text-primary"> Edite la Publicación</h3>
-                                    </div>
-                                    <form class="user" [formGroup]="publiForm">
-                                        <div class="form-group row">
-                                            <div class="col-sm-6 mb-3 mb-sm-0">
-                                                <input type="text" class="form-control form-control-user" id="Titulo"
-                                                    formControlName="Titulo" name="Titulo"
-                                                    placeholder="{{publi?.titulo}}" value="{{publi.titulo}}">
-                                            </div>
-                                            <div *ngIf="publiForm.controls['Titulo'].invalid && (publiForm.controls['Titulo'].dirty || publiForm.controls['Titulo'].touched)"
-                                                class="alert alert-danger">
-                                                <p *ngIf="publiForm.controls['Titulo'].errors?.['required']">
-                                                    Se requiere un título para la publicación.
-                                                </p>
-                                            </div>
-
-                                            <div class="col-sm-6">
-                                                <input type="text" class="form-control form-control-user" id="Enunciado"
-                                                    formControlName="Enunciado" name="Enunciado"
-                                                    placeholder="{{publi?.enunciado}}" value="{{publi.enunciado}}">
-                                            </div>
-                                            <div *ngIf="publiForm.controls['Enunciado'].invalid && (publiForm.controls['Enunciado'].dirty || publiForm.controls['Enunciado'].touched)"
-                                                class="alert alert-danger">
-                                                <p *ngIf="publiForm.controls['Enunciado'].errors?.['required']">
-                                                    Se requiere que la publicación tenga un enunciado.
-                                                </p>
-                                            </div>
+                                <div *ngIf="esalumno==0">
+                                    <div class="row">
+                                        <div class="col-6">
+                                            <button class="btn btn-primary"
+                                                (click)="inicio_edicion(1, indice, publi.titulo, publi.enunciado, publi.IsFijo)">
+                                                Editar
+                                            </button>
+                                            &nbsp;
+                                            <button class="btn btn-danger" (click)="eliminar(publi.id, 1, indice)">
+                                                Eliminar
+                                            </button>
                                         </div>
-                                        <p></p>
-                                        <select class="form-select" name="IsFijo" id="IsFijo" formControlName="IsFijo"
-                                            value="{{publi?.IsFijo}}">
-                                            <option value="" disabled selected>Fijar Publicacion</option>
-                                            <option value="1">Si</option>
-                                            <option value="0">No</option>
-                                        </select>
-                                        <button type="submit" class="btn btn-primary btn-user btn-block"
-                                            style="width: 150px;"
-                                            (click)="edicion(publi.id, 1, indice)">Confirmar</button>
-                                        <button class="btn btn-danger btn-lg btn-block" style="width: 150px;"
-                                            (click)="terminar_edicion(1, indice)">Cancelar</button>
-                                    </form>
+                                    </div>
+
+                                    <div class="card shadow mb-4" *ngIf="fixed_edit_flags[indice] == 1">
+                                        <div class="card-header py3">
+                                            <h3 class="m-0 font-weight-bold text-primary"> Edite la Publicación</h3>
+                                        </div>
+                                        <form class="user" [formGroup]="publiForm">
+                                            <div class="form-group row">
+                                                <div class="col-sm-6 mb-3 mb-sm-0">
+                                                    <input type="text" class="form-control form-control-user" id="Titulo"
+                                                        formControlName="Titulo" name="Titulo"
+                                                        placeholder="{{publi?.titulo}}" value="{{publi.titulo}}">
+                                                </div>
+                                                <div *ngIf="publiForm.controls['Titulo'].invalid && (publiForm.controls['Titulo'].dirty || publiForm.controls['Titulo'].touched)"
+                                                    class="alert alert-danger">
+                                                    <p *ngIf="publiForm.controls['Titulo'].errors?.['required']">
+                                                        Se requiere un título para la publicación.
+                                                    </p>
+                                                </div>
+
+                                                <div class="col-sm-6">
+                                                    <input type="text" class="form-control form-control-user" id="Enunciado"
+                                                        formControlName="Enunciado" name="Enunciado"
+                                                        placeholder="{{publi?.enunciado}}" value="{{publi.enunciado}}">
+                                                </div>
+                                                <div *ngIf="publiForm.controls['Enunciado'].invalid && (publiForm.controls['Enunciado'].dirty || publiForm.controls['Enunciado'].touched)"
+                                                    class="alert alert-danger">
+                                                    <p *ngIf="publiForm.controls['Enunciado'].errors?.['required']">
+                                                        Se requiere que la publicación tenga un enunciado.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <p></p>
+                                            <select class="form-select" name="IsFijo" id="IsFijo" formControlName="IsFijo"
+                                                value="{{publi?.IsFijo}}">
+                                                <option value="" disabled selected>Fijar Publicacion</option>
+                                                <option value="1">Si</option>
+                                                <option value="0">No</option>
+                                            </select>
+                                            <button type="submit" class="btn btn-primary btn-user btn-block"
+                                                style="width: 150px;"
+                                                (click)="edicion(publi.id, 1, indice)">Confirmar</button>
+                                            <button class="btn btn-danger btn-lg btn-block" style="width: 150px;"
+                                                (click)="terminar_edicion(1, indice)">Cancelar</button>
+                                        </form>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -276,6 +275,7 @@
                             </div>
                         </div>
                     </div>
+                    <br>
                 </div>
             </div>
         </div>

--- a/src/app/vistas/publicaciones/publicaciones.component.html
+++ b/src/app/vistas/publicaciones/publicaciones.component.html
@@ -59,48 +59,65 @@
                                         </div>
                                     </div>
 
-                                    <div class="card shadow mb-4" *ngIf="fixed_edit_flags[indice] == 1">
-                                        <div class="card-header py3">
-                                            <h3 class="m-0 font-weight-bold text-primary"> Edite la Publicación</h3>
-                                        </div>
+                                    <div class="shadow mb-4" *ngIf="fixed_edit_flags[indice] == 1">
                                         <form class="user" [formGroup]="publiForm">
-                                            <div class="form-group row">
-                                                <div class="col-sm-6 mb-3 mb-sm-0">
-                                                    <input type="text" class="form-control form-control-user" id="Titulo"
-                                                        formControlName="Titulo" name="Titulo"
-                                                        placeholder="{{publi?.titulo}}" value="{{publi.titulo}}">
-                                                </div>
-                                                <div *ngIf="publiForm.controls['Titulo'].invalid && (publiForm.controls['Titulo'].dirty || publiForm.controls['Titulo'].touched)"
-                                                    class="alert alert-danger">
-                                                    <p *ngIf="publiForm.controls['Titulo'].errors?.['required']">
-                                                        Se requiere un título para la publicación.
-                                                    </p>
+                                            <div class="container">
+                                                <div class="form-group row">
+                                                    <div class="col-sm-6 mb-3 mb-sm-0">
+                                                        <input type="text" class="form-control form-control-user"
+                                                            id="Titulo" formControlName="Titulo" name="Titulo"
+                                                            placeholder="{{publi?.titulo}}" value="{{publi.titulo}}">
+                                                    </div>
+                                                    <div *ngIf="publiForm.controls['Titulo'].invalid && (publiForm.controls['Titulo'].dirty || publiForm.controls['Titulo'].touched)"
+                                                        class="alert alert-danger">
+                                                        <p *ngIf="publiForm.controls['Titulo'].errors?.['required']">
+                                                            Se requiere un título para la publicación.
+                                                        </p>
+                                                    </div>
+
+                                                    <div class="col-sm-6">
+                                                        <input type="text" class="form-control form-control-user"
+                                                            id="Enunciado" formControlName="Enunciado" name="Enunciado"
+                                                            placeholder="{{publi?.enunciado}}"
+                                                            value="{{publi.enunciado}}">
+                                                    </div>
+                                                    <div *ngIf="publiForm.controls['Enunciado'].invalid && (publiForm.controls['Enunciado'].dirty || publiForm.controls['Enunciado'].touched)"
+                                                        class="alert alert-danger">
+                                                        <p *ngIf="publiForm.controls['Enunciado'].errors?.['required']">
+                                                            Se requiere que la publicación tenga un enunciado.
+                                                        </p>
+                                                    </div>
                                                 </div>
 
-                                                <div class="col-sm-6">
-                                                    <input type="text" class="form-control form-control-user" id="Enunciado"
-                                                        formControlName="Enunciado" name="Enunciado"
-                                                        placeholder="{{publi?.enunciado}}" value="{{publi.enunciado}}">
+                                                <div class="col-6 mb-2">
+                                                    <div class="row">
+                                                        <div class="col-6">
+                                                            <select class="form-select" name="IsFijo" id="IsFijo"
+                                                                formControlName="IsFijo" value="{{publi.IsFijo}}">
+                                                                <option value="" disabled selected>Fijar Publicacion
+                                                                </option>
+                                                                <option value="1">Si</option>
+                                                                <option value="0">No</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                                <div *ngIf="publiForm.controls['Enunciado'].invalid && (publiForm.controls['Enunciado'].dirty || publiForm.controls['Enunciado'].touched)"
-                                                    class="alert alert-danger">
-                                                    <p *ngIf="publiForm.controls['Enunciado'].errors?.['required']">
-                                                        Se requiere que la publicación tenga un enunciado.
-                                                    </p>
+                                                <div class="col-6">
+                                                    <div class="row">
+                                                        <div class="col-6">
+                                                            <button type="submit" class="btn btn-primary"
+                                                                (click)="edicion(publi.id, 1, indice)">Publicar</button>
+                                                            <button class="btn btn-danger"
+                                                                (click)="terminar_edicion(1, indice)">Cancelar</button>
+                                                        </div>
+                                                        <!-- <div class="col-6">
+                                                            
+                                                        </div> -->
+
+                                                    </div>
                                                 </div>
                                             </div>
-                                            <p></p>
-                                            <select class="form-select" name="IsFijo" id="IsFijo" formControlName="IsFijo"
-                                                value="{{publi?.IsFijo}}">
-                                                <option value="" disabled selected>Fijar Publicacion</option>
-                                                <option value="1">Si</option>
-                                                <option value="0">No</option>
-                                            </select>
-                                            <button type="submit" class="btn btn-primary btn-user btn-block"
-                                                style="width: 150px;"
-                                                (click)="edicion(publi.id, 1, indice)">Confirmar</button>
-                                            <button class="btn btn-danger btn-lg btn-block" style="width: 150px;"
-                                                (click)="terminar_edicion(1, indice)">Cancelar</button>
+
                                         </form>
                                     </div>
                                 </div>


### PR DESCRIPTION
Arreglado algunos detalles estéticos de la vista publicaciones:
- Botones de las publicaciones fijadas mejor colocadas y ya no están pegados al card respectivo
- Botones para editar publicaciones mejor colocadas y ya no están pegados al card respectivo
- br al fondo para que el botón de crear publicación no se encuentre pegado al fondo de la página.