### PR TITLE
Fix nuevaconfig sin ramos sin aptitudes

### DIFF
--- a/src/app/componentes/barra-lateral-encargado/barra-lateral-encargado.component.html
+++ b/src/app/componentes/barra-lateral-encargado/barra-lateral-encargado.component.html
@@ -23,9 +23,18 @@
     </div>
 
     <li class="nav-item">
-        <a class="nav-link" routerLink="/detalles/practicas">
+        <a *ngIf="ramos_creados && aptitudes_creadas;else config_practica_disabled" class="nav-link"
+            routerLink="/detalles/practicas">
             <i class="fas fa-fw fa-cog"></i>
-            <span>Configurar prácticas</span></a>
+            <span>Configurar prácticas</span>
+        </a>
+        <ng-template #config_practica_disabled>
+            <a title="Debe crear agregar aptitudes y ramos antes de crear prácticas" class="nav-link"
+                style="color: gray; cursor: not-allowed;">
+                <i class="fas fa-fw fa-cog" style="color: gray;"></i>
+                <span>Configurar prácticas</span>
+            </a>
+        </ng-template>
     </li>
 
     <!-- Nav Item - Config Practicas Collapse Menu -->
@@ -105,10 +114,12 @@
         </a>
         <div id="menu_guias" class="collapse" aria-labelledby="menu_guias" data-parent="#accordionSidebar">
             <div class="bg-white py-2 collapse-inner rounded">
-                <a class="collapse-item" [routerLink]="['/guias/info_y_eval_estudiante']" data-toggle="modal" style="white-space:break-spaces; word-wrap: break-word;">
+                <a class="collapse-item" [routerLink]="['/guias/info_y_eval_estudiante']" data-toggle="modal"
+                    style="white-space:break-spaces; word-wrap: break-word;">
                     Evaluar estudiantes
                 </a>
-                <a class="collapse-item" [routerLink]="['/guias/config-practica']" data-toggle="modal" style="white-space:break-spaces; word-wrap: break-word;">
+                <a class="collapse-item" [routerLink]="['/guias/config-practica']" data-toggle="modal"
+                    style="white-space:break-spaces; word-wrap: break-word;">
                     Crear configuración de práctica
                 </a>
             </div>

--- a/src/app/componentes/barra-lateral-encargado/barra-lateral-encargado.component.ts
+++ b/src/app/componentes/barra-lateral-encargado/barra-lateral-encargado.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { BarraLateralService } from 'src/app/servicios/encargado/barra-lateral/barra-lateral.service';
 import { RamosService } from 'src/app/servicios/encargado/ramos/ramos.service';
+import { AptitudService } from "src/app/servicios/encargado/aptitud.service";
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -15,11 +16,12 @@ export class BarraLateralEncargadoComponent {
   practicas_creadas: any = [];
   configs_nombres: any = [];
   ramos_creados: boolean = false;
+  aptitudes_creadas: boolean = false;
 
   user: any = window.localStorage.getItem('auth-user');
   id_carrera: number = JSON.parse(this.user).userdata.encargado.id_carrera;
 
-  constructor(private service: BarraLateralService, private _snackBar: MatSnackBar, private serviceRamos: RamosService) {
+  constructor(private service: BarraLateralService, private _snackBar: MatSnackBar, private serviceRamos: RamosService, private aptitudService: AptitudService) {
 
     let respuesta: any = {};
 
@@ -68,12 +70,25 @@ export class BarraLateralEncargadoComponent {
         console.log("error:", error);
       },
       complete: () => {
-        //console.log("respuesta:", respuesta.body)
         if (respuesta.body.ramos != "" && respuesta.body.ramos != null) {
           this.ramos_creados = true;
         }
       }
     });
+
+    let res_aptitudes: any = {};
+    this.aptitudService.getAptitudes(this.id_carrera).subscribe({
+      next: (data: any) => {
+        res_aptitudes = { ...res_aptitudes, ...data }
+      },
+      error: (error: any) => {
+      },
+      complete: () => {
+        if (res_aptitudes.status == 200 && res_aptitudes.body.data && res_aptitudes.body.data.length > 0) {
+          this.aptitudes_creadas = true;
+        }
+      }
+    })
 
   }
 }


### PR DESCRIPTION
En la misma interfaz se pueden borrar o agregar aptitudes y ramos. Debería desactivarse el botón de config practica cuando no haya alguna de las 2