### PR TITLE
agregado interceptor de auth

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -61,7 +61,7 @@ const routes: Routes = [
           { path: 'empresas', component: EmpresasComponent },
           { path: 'iniciarpractica/:n', component: IniciarPracticaComponent },
           { path: 'perfil', component: PerfilComponent },
-          { path: 'publicaciones', component: PublicacionesComponent}
+          { path: 'publicaciones', component: PublicacionesComponent }
         ]
       }
     ]
@@ -73,9 +73,9 @@ const routes: Routes = [
   { path: 'blank', component: BlankComponent },
   { path: 'resetPass', component: ForgotPasswordComponent },
   { path: 'estadisticas', component: EstadisticasComponent },
-  { path: 'documentacion', component: DocumentacionComponent},
-  { 
-    path: 'admin', 
+  { path: 'documentacion', component: DocumentacionComponent },
+  {
+    path: 'admin',
     children: [
       { path: '', component: AdminComponent },
     ]
@@ -88,7 +88,7 @@ const routes: Routes = [
   { path: environment.ruta_alumno + '/:id/chat/:room/:id1/:id2/:tipo', component: ChatComponent },
   { path: environment.ruta_alumno + '/:id/historial', component: NotisHistorialComponent },
   { path: "historial", component: NotisHistorialComponent },
-  { path: 'publicaciones', component: PublicacionesComponent},
+  { path: 'publicaciones', component: PublicacionesComponent },
   { path: 'chat/:room/:id1/:id2/:tipo', component: ChatComponent },
   { path: 'informe/:id_practica/:id_informe', component: InformeComponent },
   { path: 'encuestaFinal/:id_practica', component: EncuestaFinPracticaComponent },
@@ -103,8 +103,8 @@ const routes: Routes = [
   { path: 'guias/config-practica', component: ConfigPracticaComponent },
   { path: 'perfil', component: PerfilComponent },
   { path: "plagios/:id_practica", component: PlagiosComponent },
-  { path: 'documentacion', component: DocumentacionComponent},
-  { path: 'confirmar-inicio-practica', component: ConfirmarInicioPracticaComponent},
+  { path: 'documentacion', component: DocumentacionComponent },
+  { path: 'confirmar-inicio-practica', component: ConfirmarInicioPracticaComponent },
   { path: 'usuario/confirmacion', component: ConfirmacionUsuarioComponent },
   { path: '**', component: PnfComponent },
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,7 +21,7 @@ import { MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
-
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -95,7 +95,8 @@ import { ConfirmarInicioPracticaComponent } from './vistas/confirmar-inicio-prac
 import { ConfirmacionUsuarioComponent } from './vistas/confirmacion-usuario/confirmacion-usuario.component';
 import { SubirArchivoInformeFinalComponent } from './componentes/subir-archivo-informe-final/subir-archivo-informe-final.component';
 import { EditarArchivoEncargadoComponent } from './componentes/editar-archivo-encargado/editar-archivo-encargado.component';
-import { AgregarDominioModalComponent } from "./componentes/agregar-dominio-modal/agregar-dominio-modal.component"
+import { AgregarDominioModalComponent } from "./componentes/agregar-dominio-modal/agregar-dominio-modal.component";
+import { authInterceptor } from "./interceptores/auth/auth.interceptor";
 
 @NgModule({
   declarations: [
@@ -198,6 +199,7 @@ import { AgregarDominioModalComponent } from "./componentes/agregar-dominio-moda
     ArchivosService,
     SupervisorService,
     CookieService,
+    provideHttpClient(withInterceptors([authInterceptor])),
     { provide: MAT_DATE_LOCALE, useValue: 'es-ES' }],
   bootstrap: [AppComponent]
 })

--- a/src/app/interceptores/auth/auth.interceptor.spec.ts
+++ b/src/app/interceptores/auth/auth.interceptor.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpInterceptorFn } from '@angular/common/http';
+
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) => 
+    TestBed.runInInjectionContext(() => authInterceptor(req, next));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/interceptores/auth/auth.interceptor.ts
+++ b/src/app/interceptores/auth/auth.interceptor.ts
@@ -1,0 +1,20 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { environment } from 'src/environments/environment';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const router = new Router();
+  const token = JSON.parse(localStorage.getItem("auth-user") ?? "{}").token;
+  if (router.url !== "/" && router.url !== `/${environment.ruta_login}`) {
+    if (!token) {
+      router.navigateByUrl(`/`);
+    }
+  }
+
+  const authReq = req.clone({
+    setHeaders: {
+      Authorization: `${token}`
+    }
+  });
+  return next(authReq);
+};

--- a/src/app/servicios/notificaciones/notificaciones.service.ts
+++ b/src/app/servicios/notificaciones/notificaciones.service.ts
@@ -26,11 +26,10 @@ export class NotificacionesService extends Socket {
       url: environment.url_back_chat,
       options: {
         query: {
-          nameRoom: "notificaciones" + JSON.parse(localStorage.getItem("auth-user") || "{}").userdata.id
+          nameRoom: "notificaciones" + JSON.parse(localStorage.getItem("auth-user") || "{}").userdata?.id
         },
       }
     });
-    //console.log("sala notificaciones" + JSON.parse(localStorage.getItem("auth-user") || "{}").userdata.id);
     this.listen();
   }
 
@@ -50,7 +49,7 @@ export class NotificacionesService extends Socket {
 
 
   notificaciones_vistas(id_usuario: number) {
-    const req = new HttpRequest('PUT', `${environment.url_back}/notificacion/visto`, { id_usuario }, {responseType:"text"});
+    const req = new HttpRequest('PUT', `${environment.url_back}/notificacion/visto`, { id_usuario }, { responseType: "text" });
     return this._http.request(req);
   }
 


### PR DESCRIPTION
Para agregar el token entregado al cliente al iniciar sesión al header Authorization y también solucionado error que generaba que la página se fuera a blanco si ingresabas a un link sin iniciar sesión.

Esta pr requiere de la pr del back https://github.com/LogiLinkP/praxus-node-backend/pull/177